### PR TITLE
macOS support: AVCodecs+VTCodecs VideoToolbox encoding, Live555 arm64

### DIFF
--- a/RealGazebo.uplugin
+++ b/RealGazebo.uplugin
@@ -19,43 +19,41 @@
 			"Name": "RealGazebo",
 			"Type": "Runtime",
 			"LoadingPhase": "Default",
-			"PlatformAllowList": [
-				"Win64",
-				"Linux"
-			]
+			"PlatformAllowList": [ "Win64", "Linux", "Mac" ]
 		},
 		{
 			"Name": "RealGazeboBridge",
 			"Type": "Runtime",
 			"LoadingPhase": "Default",
-			"PlatformAllowList": [
-				"Win64",
-				"Linux"
-			]
+			"PlatformAllowList": [ "Win64", "Linux", "Mac" ]
 		},
 		{
 			"Name": "RealGazeboUI",
 			"Type": "Runtime",
 			"LoadingPhase": "PostEngineInit",
-			"PlatformAllowList": [
-				"Win64",
-				"Linux"
-			]
+			"PlatformAllowList": [ "Win64", "Linux", "Mac" ]
 		},
 		{
 			"Name": "RealGazeboStreaming",
 			"Type": "Runtime",
 			"LoadingPhase": "PostEngineInit",
-			"PlatformAllowList": [
-				"Win64",
-				"Linux"
-			]
+			"PlatformAllowList": [ "Win64", "Linux", "Mac" ]
 		}
 	],
 	"Plugins": [
 		{
 			"Name": "HardwareEncoders",
 			"Enabled": true
+		},
+		{
+			"Name": "AVCodecsCore",
+			"Enabled": true,
+			"PlatformAllowList": [ "Mac" ]
+		},
+		{
+			"Name": "VTCodecs",
+			"Enabled": true,
+			"PlatformAllowList": [ "Mac" ]
 		}
 	]
 }

--- a/Source/RealGazeboStreaming/Private/Encoder/EncoderConfig.cpp
+++ b/Source/RealGazeboStreaming/Private/Encoder/EncoderConfig.cpp
@@ -5,25 +5,17 @@
 // See LICENSE file in the project root for full license information.
 
 #include "Encoder/EncoderConfig.h"
-#include "VideoEncoder.h"  // For FVideoEncoder::H264Profile, RateControlMode, etc.
 
-//----------------------------------------------------------
-// AVEncoder API Mapping (UE 5.1)
-//----------------------------------------------------------
+#if !PLATFORM_MAC
+#include "VideoEncoder.h"
 
 AVEncoder::FVideoEncoder::H264Profile FEncoderConfig::GetAVEncoderProfile() const
 {
-	// Always use BASELINE profile for maximum compatibility
-	// Baseline = no B-frames, no CABAC, simple decode
-	// Supported by all H.264 decoders including embedded/mobile
 	return AVEncoder::FVideoEncoder::H264Profile::BASELINE;
 }
 
 AVEncoder::FVideoEncoder::RateControlMode FEncoderConfig::GetRateControlMode() const
 {
-	// Use Constant Bitrate (CBR) for consistent, predictable latency
-	// CBR maintains steady bitrate -> steady network usage -> predictable latency
-	// Alternative VBR (Variable Bitrate) would give better quality but unpredictable latency
 	return bConstantBitrate
 		? AVEncoder::FVideoEncoder::RateControlMode::CBR
 		: AVEncoder::FVideoEncoder::RateControlMode::VBR;
@@ -31,11 +23,8 @@ AVEncoder::FVideoEncoder::RateControlMode FEncoderConfig::GetRateControlMode() c
 
 AVEncoder::FVideoEncoder::MultipassMode FEncoderConfig::GetMultipassMode() const
 {
-	// Multipass encoding analyzes video in multiple passes for better quality
-	// But adds latency (must buffer frames for analysis)
-	// For ultra-low latency, always use single-pass
 	return bMultipass
 		? AVEncoder::FVideoEncoder::MultipassMode::FULL
 		: AVEncoder::FVideoEncoder::MultipassMode::DISABLED;
 }
-
+#endif

--- a/Source/RealGazeboStreaming/Private/Encoder/HardwareEncoderWrapper.cpp
+++ b/Source/RealGazeboStreaming/Private/Encoder/HardwareEncoderWrapper.cpp
@@ -1,39 +1,21 @@
 // Copyright (c) 2024-2025 SUV Lab, Chungbuk National University
-// Author    : Gonapinuwala Lahiru Sandaruwan
-// Supervisor: Prof. SungTae Moon - Project lead & research supervision
 // Licensed under the GNU General Public License v3.0.
-// See LICENSE file in the project root for full license information.
+
+#if !PLATFORM_MAC
+// Preserve the current upstream Windows/Linux implementation byte-for-byte.
+#include "HardwareEncoderWrapper.upstream.inc"
+#else
 
 #include "Encoder/HardwareEncoderWrapper.h"
-#include "VideoEncoder.h"
-#include "VideoEncoderFactory.h"
-#include "VideoEncoderCommon.h"
-#include "VideoEncoderInput.h"
-#include "CodecPacket.h"
 #include "HAL/PlatformTime.h"
-#include "Modules/ModuleManager.h"
 #include "RHI.h"
 #include "RHIResources.h"
-#include "CudaModule.h"
-
-// Vulkan RHI interface for both Windows and Linux
-#if PLATFORM_LINUX || PLATFORM_WINDOWS
-#include "IVulkanDynamicRHI.h"
-#endif
-
-#if PLATFORM_LINUX
-#include <unistd.h>
-#endif
-
-// CUDA support for NVENC on Linux is included above (line 17)
-
-//----------------------------------------------------------
-// Construction & Initialization
-//----------------------------------------------------------
+#include "UObject/UObjectGlobals.h"
+#include "Video/Encoders/SimpleVideoEncoder.h"
 
 FHardwareEncoderWrapper::FHardwareEncoderWrapper()
 {
-	UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Created"));
+	UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Created (macOS VideoToolbox)"));
 }
 
 FHardwareEncoderWrapper::~FHardwareEncoderWrapper()
@@ -48,33 +30,17 @@ bool FHardwareEncoderWrapper::Initialize(const FEncoderConfig& InConfig, FString
 		OutErrorMessage = TEXT("Encoder already initialized");
 		return true;
 	}
-
-	UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Initializing..."));
-	UE_LOG(LogTemp, Log, TEXT("  Config: %s"), *InConfig.ToString());
-
-	// Validate configuration
 	if (!InConfig.Validate(OutErrorMessage))
 	{
-		UE_LOG(LogTemp, Error, TEXT("HardwareEncoderWrapper: Invalid config - %s"), *OutErrorMessage);
 		return false;
 	}
-
 	Config = InConfig;
-
-	// Create hardware encoder (NVENC or AMF)
 	if (!CreateHardwareEncoder(OutErrorMessage))
 	{
-		UE_LOG(LogTemp, Error, TEXT("HardwareEncoderWrapper: Failed to create encoder - %s"), *OutErrorMessage);
 		return false;
 	}
-
-	// Register callbacks
 	RegisterEncoderCallbacks();
-
 	bInitialized = true;
-	UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Initialized successfully (%s)"),
-		*EncoderTypeToString(EncoderType));
-
 	return true;
 }
 
@@ -84,967 +50,191 @@ void FHardwareEncoderWrapper::Shutdown()
 	{
 		return;
 	}
-
-	const uint64 FramesEncoded = TotalFramesEncoded.load();
-	UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Shutting down... (Encoded %llu frames)"), FramesEncoded);
 	bShuttingDown = true;
-
-	// Flush input first to complete pending operations
-	if (VideoEncoderInput)
+	if (AVCodecEncoder)
 	{
-		VideoEncoderInput->Flush();
+		AVCodecEncoder->Close();
+		AVCodecEncoder->RemoveFromRoot();
+		AVCodecEncoder->ConditionalBeginDestroy();
+		AVCodecEncoder = nullptr;
 	}
-
-	// WORKAROUND: UE5 NVENC bug - Shutdown() crashes if no frames were encoded
-	// because internal buffers were never allocated
-	if (FramesEncoded > 0)
-	{
-		// Frames were encoded - safe to shutdown normally
-		FPlatformProcess::Sleep(0.05f);
-
-		if (VideoEncoder)
-		{
-			VideoEncoder->Shutdown();
-			VideoEncoder.Reset();
-		}
-		if (VideoEncoderInput)
-		{
-			VideoEncoderInput.Reset();
-		}
-	}
-	else
-	{
-		// No frames encoded - NVENC internal buffers not allocated
-		// Must prevent destructor from running (it calls Shutdown which crashes)
-		// Store in static array to keep alive (intentional leak for stability)
-		UE_LOG(LogTemp, Warning, TEXT("HardwareEncoderWrapper: No frames encoded - leaking NVENC to prevent crash"));
-		static TArray<TUniquePtr<AVEncoder::FVideoEncoder>> LeakedEncoders;
-		static TArray<TSharedPtr<AVEncoder::FVideoEncoderInput>> LeakedInputs;
-		if (VideoEncoder)
-		{
-			LeakedEncoders.Add(MoveTemp(VideoEncoder));
-		}
-		if (VideoEncoderInput)
-		{
-			LeakedInputs.Add(VideoEncoderInput);
-			VideoEncoderInput.Reset();
-		}
-	}
-
-	// Clear CUDA texture cache (releases cached CUarrays)
-	ClearCUDATextureCache();
-
 	bInitialized = false;
 	bShuttingDown = false;
-
-	UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Shutdown complete (Encoded: %llu frames, %llu keyframes, %.2f MB)"),
-		FramesEncoded,
-		TotalKeyframesEncoded.load(),
-		TotalBytesOutput.load() / (1024.0 * 1024.0));
 }
-
-//----------------------------------------------------------
-// Internal Initialization
-//----------------------------------------------------------
 
 bool FHardwareEncoderWrapper::CreateHardwareEncoder(FString& OutErrorMessage)
 {
-	// Step 1: Create VideoEncoderInput based on RHI type
 	if (!GDynamicRHI)
 	{
 		OutErrorMessage = TEXT("RHI not initialized");
 		return false;
 	}
-
-	const ERHIInterfaceType RHIType = RHIGetInterfaceType();
-
-#if PLATFORM_WINDOWS
-	if (RHIType == ERHIInterfaceType::D3D11)
+	if (RHIGetInterfaceType() != ERHIInterfaceType::Metal)
 	{
-		VideoEncoderInput = AVEncoder::FVideoEncoderInput::CreateForD3D11(
-			GDynamicRHI->RHIGetNativeDevice(),
-			true,  // IsResizable
-			IsRHIDeviceAMD()  // IsShared (for AMD compatibility)
-		);
-	}
-	else if (RHIType == ERHIInterfaceType::D3D12)
-	{
-		// IMPORTANT: On Windows D3D12 with NVIDIA GPUs, NVENC requires a D3D11 device
-		// for encoding. This means we MUST use IsShared=true to create a D3D11 intermediate
-		// device that NVENC can use.
-		//
-		// UE5.1 BUG WORKAROUND:
-		// When IsShared=true, there's a bug where pooled input frames don't properly clear
-		// D3D12.Texture before reuse, causing check(D3D12.Texture == nullptr) to fail.
-		//
-		// Solution: Use IsShared=true (required for NVENC) and set MaxNumBuffers=1 to
-		// prevent frame pooling/reuse. Each encoding will create a new frame, avoiding
-		// the assertion failure.
-		VideoEncoderInput = AVEncoder::FVideoEncoderInput::CreateForD3D12(
-			GDynamicRHI->RHIGetNativeDevice(),
-			true,  // IsResizable
-			true   // IsShared - MUST be true for NVENC (needs D3D11 device)
-		);
-
-		// CRITICAL: Set MaxNumBuffers=1 to prevent frame reuse bug
-		// This avoids the check(D3D12.Texture == nullptr) assertion failure
-		if (VideoEncoderInput.IsValid())
-		{
-			VideoEncoderInput->SetMaxNumBuffers(1);
-			UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: D3D12 shared mode with MaxNumBuffers=1 (NVENC workaround)"));
-		}
-	}
-	else if (RHIType == ERHIInterfaceType::Vulkan)
-	{
-		// Windows Vulkan support
-		IVulkanDynamicRHI* VulkanRHI = GetIVulkanDynamicRHI();
-		if (!VulkanRHI)
-		{
-			OutErrorMessage = TEXT("Failed to get Vulkan RHI interface on Windows");
-			return false;
-		}
-
-		AVEncoder::FVulkanDataStruct VulkanData;
-		VulkanData.VulkanInstance = VulkanRHI->RHIGetVkInstance();
-		VulkanData.VulkanPhysicalDevice = VulkanRHI->RHIGetVkPhysicalDevice();
-		VulkanData.VulkanDevice = VulkanRHI->RHIGetVkDevice();
-
-		UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Windows Vulkan - Instance=%p, PhysicalDevice=%p, Device=%p"),
-			VulkanData.VulkanInstance, VulkanData.VulkanPhysicalDevice, VulkanData.VulkanDevice);
-
-		VideoEncoderInput = AVEncoder::FVideoEncoderInput::CreateForVulkan(
-			&VulkanData,
-			true  // IsResizable
-		);
-	}
-	else
-#elif PLATFORM_LINUX
-	if (RHIType == ERHIInterfaceType::Vulkan)
-	{
-		// On Linux with NVIDIA GPU, NVENC doesn't support Vulkan textures directly.
-		// We must use CUDA instead. Check if CUDA module is available.
-		UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Linux Vulkan detected, checking for CUDA..."));
-
-		FCUDAModule* CudaModule = FModuleManager::GetModulePtr<FCUDAModule>("CUDA");
-		UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: CUDA module ptr = %p"), CudaModule);
-
-		if (CudaModule)
-		{
-			const bool bCudaAvailable = CudaModule->IsAvailable();
-			UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: CUDA IsAvailable() = %s"), bCudaAvailable ? TEXT("true") : TEXT("false"));
-
-			if (bCudaAvailable)
-			{
-				// NVIDIA GPU detected - use CUDA for NVENC (NVENC supports CUDA_R8G8B8A8_UNORM)
-				CUcontext LocalCudaContext = CudaModule->GetCudaContext();
-				UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: CUDA context = %p"), LocalCudaContext);
-
-				if (LocalCudaContext)
-				{
-					UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Using CUDA for NVENC encoding (CudaContext=%p)"), LocalCudaContext);
-
-					VideoEncoderInput = AVEncoder::FVideoEncoderInput::CreateForCUDA(
-						LocalCudaContext,
-						true  // IsResizable
-					);
-
-					if (VideoEncoderInput.IsValid())
-					{
-						bUseCUDAMode = true;
-						CudaContext = LocalCudaContext;
-						UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: CUDA encoder input created successfully"));
-					}
-					else
-					{
-						UE_LOG(LogTemp, Warning, TEXT("HardwareEncoderWrapper: CreateForCUDA failed - falling back to Vulkan"));
-					}
-				}
-				else
-				{
-					UE_LOG(LogTemp, Warning, TEXT("HardwareEncoderWrapper: CUDA available but no context - falling back to Vulkan"));
-				}
-			}
-		}
-		else
-		{
-			UE_LOG(LogTemp, Warning, TEXT("HardwareEncoderWrapper: CUDA module not loaded - using Vulkan"));
-		}
-
-		// Fallback to Vulkan if CUDA failed (for AMD GPUs which support Vulkan via AMF)
-		if (!VideoEncoderInput.IsValid())
-		{
-			IVulkanDynamicRHI* VulkanRHI = GetIVulkanDynamicRHI();
-			if (!VulkanRHI)
-			{
-				OutErrorMessage = TEXT("Failed to get Vulkan RHI interface");
-				return false;
-			}
-
-			AVEncoder::FVulkanDataStruct VulkanData;
-			VulkanData.VulkanInstance = VulkanRHI->RHIGetVkInstance();
-			VulkanData.VulkanPhysicalDevice = VulkanRHI->RHIGetVkPhysicalDevice();
-			VulkanData.VulkanDevice = VulkanRHI->RHIGetVkDevice();
-
-			UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Using Vulkan for AMF encoding - Instance=%p, PhysicalDevice=%p, Device=%p"),
-				VulkanData.VulkanInstance, VulkanData.VulkanPhysicalDevice, VulkanData.VulkanDevice);
-
-			VideoEncoderInput = AVEncoder::FVideoEncoderInput::CreateForVulkan(
-				&VulkanData,
-				true  // IsResizable
-			);
-		}
-	}
-	else
-#endif
-	{
-		OutErrorMessage = FString::Printf(TEXT("Unsupported RHI type for encoding: %d"), (int32)RHIType);
+		OutErrorMessage = TEXT("macOS VideoToolbox encoder requires Metal RHI");
 		return false;
 	}
 
-	if (!VideoEncoderInput.IsValid())
+	AVCodecEncoder = NewObject<USimpleVideoEncoder>(GetTransientPackage());
+	if (!AVCodecEncoder)
 	{
-		OutErrorMessage = TEXT("Failed to create VideoEncoderInput");
+		OutErrorMessage = TEXT("Failed to allocate USimpleVideoEncoder");
+		return false;
+	}
+	AVCodecEncoder->AddToRoot();
+
+	FSimpleVideoEncoderConfig CodecConfig;
+	CodecConfig.Width = Config.Width;
+	CodecConfig.Height = Config.Height;
+	CodecConfig.TargetFramerate = Config.FrameRate;
+	CodecConfig.TargetBitrate = static_cast<int32>(FMath::Min<uint64>(Config.Bitrate, MAX_int32));
+	CodecConfig.MaxBitrate = static_cast<int32>(FMath::Min<uint64>(Config.Bitrate + Config.Bitrate / 5, MAX_int32));
+
+	if (!AVCodecEncoder->Open(ESimpleVideoCodec::H264, CodecConfig, false))
+	{
+		AVCodecEncoder->RemoveFromRoot();
+		AVCodecEncoder->ConditionalBeginDestroy();
+		AVCodecEncoder = nullptr;
+		OutErrorMessage = TEXT("Failed to open H.264 VideoToolbox encoder through AVCodecs/VTCodecs");
 		return false;
 	}
 
-	// Step 2: Build FLayerConfig with ALL configuration settings
-	AVEncoder::FVideoEncoder::FLayerConfig LayerConfig;
-	LayerConfig.Width = Config.Width;
-	LayerConfig.Height = Config.Height;
-	LayerConfig.MaxFramerate = Config.FrameRate;
-	LayerConfig.TargetBitrate = Config.Bitrate;
-	LayerConfig.MaxBitrate = Config.Bitrate * 1.2;  // Allow 20% overshoot
-
-	// Ultra-low latency settings
-	LayerConfig.H264Profile = Config.GetAVEncoderProfile();
-	LayerConfig.RateControlMode = Config.GetRateControlMode();
-	LayerConfig.MultipassMode = Config.GetMultipassMode();
-
-	// GOP and frame structure (critical for low latency!)
-	LayerConfig.QPMin = -1;  // Let encoder decide
-	LayerConfig.QPMax = -1;  // Let encoder decide
-
-	// Step 3: Get available encoders and create the best match
-	const TArray<AVEncoder::FVideoEncoderInfo>& AvailableEncoders =
-		AVEncoder::FVideoEncoderFactory::Get().GetAvailable();
-
-	if (AvailableEncoders.Num() == 0)
-	{
-		OutErrorMessage = TEXT("No video encoders available. Check HardwareEncoders plugin.");
-		return false;
-	}
-
-	// Try to find and create H.264 encoder (prefer NVENC, fallback to AMF)
-	for (const AVEncoder::FVideoEncoderInfo& EncoderInfo : AvailableEncoders)
-	{
-		if (EncoderInfo.CodecType == AVEncoder::ECodecType::H264)
-		{
-			// Try to create encoder
-			VideoEncoder = AVEncoder::FVideoEncoderFactory::Get().Create(
-				EncoderInfo.ID,
-				VideoEncoderInput,
-				LayerConfig
-			);
-
-			if (VideoEncoder.IsValid())
-			{
-				// Detect encoder type from ID
-				if (EncoderInfo.ID == 0)  // NVENC usually ID 0
-				{
-					EncoderType = EEncoderType::NVENC;
-					UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Created NVENC encoder"));
-				}
-				else if (EncoderInfo.ID == 1)  // AMF usually ID 1
-				{
-					EncoderType = EEncoderType::AMF;
-					UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Created AMF encoder"));
-				}
-				else
-				{
-					EncoderType = EEncoderType::Unknown;
-					UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Created H264 encoder (ID=%d)"), EncoderInfo.ID);
-				}
-
-				// Successfully created encoder - break loop
-				break;
-			}
-		}
-	}
-
-	if (!VideoEncoder.IsValid())
-	{
-		OutErrorMessage = TEXT("No H264 hardware encoder available (NVENC or AMF). Check GPU drivers and HardwareEncoders plugin.");
-		EncoderType = EEncoderType::Unknown;
-		return false;
-	}
-
+	// EEncoderType currently models NVENC/AMF only; keep Unknown rather than
+	// misreporting the backend until the public enum is extended upstream.
+	EncoderType = EEncoderType::Unknown;
 	return true;
 }
 
 void FHardwareEncoderWrapper::RegisterEncoderCallbacks()
 {
-	if (!VideoEncoder.IsValid())
-	{
-		return;
-	}
-
-	// Register output callback - called when encoder produces data
-	// UE 5.1 signature: void(uint32 LayerIndex, const TSharedPtr<FVideoEncoderInputFrame> Frame, const FCodecPacket& Packet)
-	VideoEncoder->SetOnEncodedPacket([this](uint32 LayerIndex, const TSharedPtr<AVEncoder::FVideoEncoderInputFrame> Frame, const AVEncoder::FCodecPacket& Packet)
-	{
-		OnEncodedFrame(LayerIndex, Frame, Packet);
-	});
+	// USimpleVideoEncoder exposes a pull-based packet queue.
 }
-
-//----------------------------------------------------------
-// CUDA/Vulkan Interop (Linux, NVIDIA) - WITH CACHING
-//----------------------------------------------------------
-
-void FHardwareEncoderWrapper::ClearCUDATextureCache()
-{
-#if PLATFORM_LINUX
-	FScopeLock Lock(&CUDACacheMutex);
-
-	if (CUDATextureCache.Num() == 0)
-	{
-		return;
-	}
-
-	UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Clearing CUDA texture cache (%d entries)"), CUDATextureCache.Num());
-
-	if (CudaContext)
-	{
-		FCUDAModule::CUDA().cuCtxPushCurrent(CudaContext);
-
-		for (auto& Pair : CUDATextureCache)
-		{
-			FCachedCUDATexture& Cached = Pair.Value;
-			if (Cached.bValid)
-			{
-				// Destroy linear staging array first (created via cuArrayCreate)
-				if (Cached.LinearArray)
-				{
-					FCUDAModule::CUDA().cuArrayDestroy(Cached.LinearArray);
-				}
-				// Destroy external memory resources (tiled array from Vulkan)
-				if (Cached.MipArray)
-				{
-					FCUDAModule::CUDA().cuMipmappedArrayDestroy(Cached.MipArray);
-				}
-				if (Cached.ExternalMemory)
-				{
-					FCUDAModule::CUDA().cuDestroyExternalMemory(Cached.ExternalMemory);
-				}
-			}
-		}
-
-		FCUDAModule::CUDA().cuCtxPopCurrent(nullptr);
-	}
-
-	CUDATextureCache.Empty();
-#endif
-}
-
-bool FHardwareEncoderWrapper::SetCUDATextureFromVulkan(FRHITexture* Texture,
-	TSharedPtr<AVEncoder::FVideoEncoderInputFrame> InputFrame,
-	FString& OutErrorMessage)
-{
-#if PLATFORM_LINUX
-	if (!Texture || !InputFrame.IsValid())
-	{
-		OutErrorMessage = TEXT("Invalid texture or input frame");
-		return false;
-	}
-
-	if (!CudaContext)
-	{
-		OutErrorMessage = TEXT("CUDA context not initialized");
-		return false;
-	}
-
-	const int32 TexWidth = Texture->GetSizeX();
-	const int32 TexHeight = Texture->GetSizeY();
-
-	// Validate the layout this path actually depends on, before touching CUDA.
-	// The import below hardcodes a single-mip, non-MSAA, 4-channel 8-bit 2D layout
-	// (arrayDesc.NumChannels=4, CU_AD_FORMAT_UNSIGNED_INT8, numLevels=1, Depth=0) and a row
-	// pitch of TexWidth*4. A mismatch would not fail loudly: cuMemcpy2D would copy the wrong
-	// number of bytes per row and emit a silently corrupted frame instead of an error.
-	// Note: FRHITextureDesc::IsTexture2D() also accepts Texture2DArray, which this path cannot
-	// handle, so the dimension is compared directly.
-	const FRHITextureDesc& TextureDesc = Texture->GetDesc();
-	if (TextureDesc.Dimension != ETextureDimension::Texture2D
-		|| TextureDesc.Format != PF_B8G8R8A8
-		|| TextureDesc.NumMips != 1
-		|| TextureDesc.NumSamples != 1)
-	{
-		OutErrorMessage = FString::Printf(
-			TEXT("Unsupported texture for CUDA interop: %dx%d dimension=%d format=%s mips=%d samples=%d arraysize=%d (expected Texture2D / %s / 1 mip / no MSAA)"),
-			TexWidth, TexHeight,
-			(int32)TextureDesc.Dimension,
-			GPixelFormats[TextureDesc.Format].Name,
-			(int32)TextureDesc.NumMips,
-			(int32)TextureDesc.NumSamples,
-			(int32)TextureDesc.ArraySize,
-			GPixelFormats[PF_B8G8R8A8].Name);
-
-		// EncodeFrame runs per frame and its caller already logs OutErrorMessage on every
-		// failure, so emit the detailed diagnostic only once to avoid flooding the log.
-		if (!bLoggedUnsupportedTexture)
-		{
-			bLoggedUnsupportedTexture = true;
-			UE_LOG(LogTemp, Error, TEXT("HardwareEncoderWrapper: %s"), *OutErrorMessage);
-			UE_LOG(LogTemp, Error, TEXT("HardwareEncoderWrapper:   The CUDA/Vulkan zero-copy path requires the exact layout produced by FramePool (Create2D + PF_B8G8R8A8 + 1 mip + no MSAA)."));
-			UE_LOG(LogTemp, Error, TEXT("HardwareEncoderWrapper:   Every frame using this texture will fail to encode. Repeat occurrences of this diagnostic are suppressed."));
-		}
-		return false;
-	}
-
-	FCUDAModule::CUDA().cuCtxPushCurrent(CudaContext);
-
-	// Check cache first - if we have both TiledArray and LinearArray, just copy and return
-	{
-		FScopeLock Lock(&CUDACacheMutex);
-		FCachedCUDATexture* Cached = CUDATextureCache.Find(Texture);
-		if (Cached && Cached->bValid && Cached->TiledArray && Cached->LinearArray)
-		{
-			// CRITICAL FIX: Copy from tiled (Vulkan) array to linear (NVENC-compatible) array
-			// This de-tiles the Vulkan optimal-tiled memory into linear layout
-			CUDA_MEMCPY2D CopyParams = {};
-			CopyParams.srcMemoryType = CU_MEMORYTYPE_ARRAY;
-			CopyParams.srcArray = Cached->TiledArray;
-			CopyParams.dstMemoryType = CU_MEMORYTYPE_ARRAY;
-			CopyParams.dstArray = Cached->LinearArray;
-			CopyParams.WidthInBytes = Cached->Width * 4;  // 4 bytes per pixel (BGRA)
-			CopyParams.Height = Cached->Height;
-
-			CUresult CuRes = FCUDAModule::CUDA().cuMemcpy2D(&CopyParams);
-			FCUDAModule::CUDA().cuCtxPopCurrent(nullptr);
-
-			if (CuRes != CUDA_SUCCESS)
-			{
-				OutErrorMessage = FString::Printf(TEXT("cuMemcpy2D (cached) failed (%d)"), (int32)CuRes);
-				return false;
-			}
-
-			// Pass the LINEAR array to encoder (NOT the tiled one!)
-			InputFrame->SetTexture(Cached->LinearArray, AVEncoder::FVideoEncoderInputFrame::EUnderlyingRHI::Vulkan, nullptr,
-				[](CUarray) { /* No-op: Cache owns the resources */ });
-			return true;
-		}
-	}
-
-	// Not cached - need to import Vulkan texture AND create linear staging array
-	IVulkanDynamicRHI* VulkanRHI = GetIVulkanDynamicRHI();
-	if (!VulkanRHI)
-	{
-		FCUDAModule::CUDA().cuCtxPopCurrent(nullptr);
-		OutErrorMessage = TEXT("Failed to get Vulkan RHI interface");
-		return false;
-	}
-
-	const FVulkanRHIAllocationInfo AllocationInfo = VulkanRHI->RHIGetAllocationInfo(Texture);
-	VkDevice Device = VulkanRHI->RHIGetVkDevice();
-
-	PFN_vkGetMemoryFdKHR GetMemoryFdKHR = (PFN_vkGetMemoryFdKHR)VulkanRHI->RHIGetVkDeviceProcAddr("vkGetMemoryFdKHR");
-	if (!GetMemoryFdKHR)
-	{
-		FCUDAModule::CUDA().cuCtxPopCurrent(nullptr);
-		OutErrorMessage = TEXT("vkGetMemoryFdKHR not available");
-		return false;
-	}
-
-	int Fd = -1;
-	VkMemoryGetFdInfoKHR MemoryGetFdInfoKHR{};
-	MemoryGetFdInfoKHR.sType = VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR;
-	MemoryGetFdInfoKHR.memory = AllocationInfo.Handle;
-	MemoryGetFdInfoKHR.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR;
-	MemoryGetFdInfoKHR.pNext = nullptr;
-
-	VkResult VkRes = GetMemoryFdKHR(Device, &MemoryGetFdInfoKHR, &Fd);
-	if (VkRes != VK_SUCCESS || Fd < 0)
-	{
-		FCUDAModule::CUDA().cuCtxPopCurrent(nullptr);
-		OutErrorMessage = FString::Printf(TEXT("vkGetMemoryFdKHR failed (%d)"), (int32)VkRes);
-		return false;
-	}
-
-	// === STEP 1: Import Vulkan texture as TILED CUarray (external memory) ===
-	CUexternalMemory ExternalMemory = nullptr;
-	CUmipmappedArray MipArray = nullptr;
-	CUarray TiledArray = nullptr;
-
-	CUDA_EXTERNAL_MEMORY_HANDLE_DESC ExtDesc{};
-	ExtDesc.type = CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD;
-	ExtDesc.handle.fd = Fd;
-	ExtDesc.size = AllocationInfo.Offset + AllocationInfo.Size;
-
-	CUresult CuRes = FCUDAModule::CUDA().cuImportExternalMemory(&ExternalMemory, &ExtDesc);
-	if (CuRes != CUDA_SUCCESS)
-	{
-		FCUDAModule::CUDA().cuCtxPopCurrent(nullptr);
-		close(Fd);
-		OutErrorMessage = FString::Printf(TEXT("cuImportExternalMemory failed (%d)"), (int32)CuRes);
-		return false;
-	}
-	// FD ownership transfers to CUDA - don't close it
-
-	CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC MipDesc{};
-	MipDesc.numLevels = 1;
-	MipDesc.offset = AllocationInfo.Offset;
-	MipDesc.arrayDesc.Width = TexWidth;
-	MipDesc.arrayDesc.Height = TexHeight;
-	MipDesc.arrayDesc.Depth = 0;
-	MipDesc.arrayDesc.NumChannels = 4;
-	MipDesc.arrayDesc.Format = CU_AD_FORMAT_UNSIGNED_INT8;
-	MipDesc.arrayDesc.Flags = CUDA_ARRAY3D_SURFACE_LDST | CUDA_ARRAY3D_COLOR_ATTACHMENT;
-
-	CuRes = FCUDAModule::CUDA().cuExternalMemoryGetMappedMipmappedArray(&MipArray, ExternalMemory, &MipDesc);
-	if (CuRes != CUDA_SUCCESS)
-	{
-		FCUDAModule::CUDA().cuDestroyExternalMemory(ExternalMemory);
-		FCUDAModule::CUDA().cuCtxPopCurrent(nullptr);
-		OutErrorMessage = FString::Printf(TEXT("cuExternalMemoryGetMappedMipmappedArray failed (%d)"), (int32)CuRes);
-		return false;
-	}
-
-	CuRes = FCUDAModule::CUDA().cuMipmappedArrayGetLevel(&TiledArray, MipArray, 0);
-	if (CuRes != CUDA_SUCCESS)
-	{
-		FCUDAModule::CUDA().cuMipmappedArrayDestroy(MipArray);
-		FCUDAModule::CUDA().cuDestroyExternalMemory(ExternalMemory);
-		FCUDAModule::CUDA().cuCtxPopCurrent(nullptr);
-		OutErrorMessage = FString::Printf(TEXT("cuMipmappedArrayGetLevel failed (%d)"), (int32)CuRes);
-		return false;
-	}
-
-	// === STEP 2: Create LINEAR staging CUarray (NOT from external memory) ===
-	// This array uses standard CUDA memory layout which NVENC can read correctly
-	CUarray LinearArray = nullptr;
-	CUDA_ARRAY_DESCRIPTOR LinearArrayDesc = {};
-	LinearArrayDesc.Width = TexWidth;
-	LinearArrayDesc.Height = TexHeight;
-	LinearArrayDesc.Format = CU_AD_FORMAT_UNSIGNED_INT8;
-	LinearArrayDesc.NumChannels = 4;
-
-	CuRes = FCUDAModule::CUDA().cuArrayCreate(&LinearArray, &LinearArrayDesc);
-	if (CuRes != CUDA_SUCCESS)
-	{
-		FCUDAModule::CUDA().cuMipmappedArrayDestroy(MipArray);
-		FCUDAModule::CUDA().cuDestroyExternalMemory(ExternalMemory);
-		FCUDAModule::CUDA().cuCtxPopCurrent(nullptr);
-		OutErrorMessage = FString::Printf(TEXT("cuArrayCreate (linear staging) failed (%d)"), (int32)CuRes);
-		return false;
-	}
-
-	// === STEP 3: Copy from tiled to linear (de-tiles the data) ===
-	CUDA_MEMCPY2D CopyParams = {};
-	CopyParams.srcMemoryType = CU_MEMORYTYPE_ARRAY;
-	CopyParams.srcArray = TiledArray;
-	CopyParams.dstMemoryType = CU_MEMORYTYPE_ARRAY;
-	CopyParams.dstArray = LinearArray;
-	CopyParams.WidthInBytes = TexWidth * 4;  // 4 bytes per pixel (BGRA)
-	CopyParams.Height = TexHeight;
-
-	CuRes = FCUDAModule::CUDA().cuMemcpy2D(&CopyParams);
-	if (CuRes != CUDA_SUCCESS)
-	{
-		FCUDAModule::CUDA().cuArrayDestroy(LinearArray);
-		FCUDAModule::CUDA().cuMipmappedArrayDestroy(MipArray);
-		FCUDAModule::CUDA().cuDestroyExternalMemory(ExternalMemory);
-		FCUDAModule::CUDA().cuCtxPopCurrent(nullptr);
-		OutErrorMessage = FString::Printf(TEXT("cuMemcpy2D (initial) failed (%d)"), (int32)CuRes);
-		return false;
-	}
-
-	FCUDAModule::CUDA().cuCtxPopCurrent(nullptr);
-
-	// Cache both the tiled (external) and linear (staging) arrays
-	{
-		FScopeLock Lock(&CUDACacheMutex);
-		FCachedCUDATexture& Cached = CUDATextureCache.Add(Texture);
-		Cached.ExternalMemory = ExternalMemory;
-		Cached.MipArray = MipArray;
-		Cached.TiledArray = TiledArray;
-		Cached.LinearArray = LinearArray;
-		Cached.Width = TexWidth;
-		Cached.Height = TexHeight;
-		Cached.bValid = true;
-	}
-
-	UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Created CUDA linear staging array %dx%d format=%s (Total cached: %d)"),
-		TexWidth, TexHeight, GPixelFormats[TextureDesc.Format].Name, CUDATextureCache.Num());
-
-	// Pass the LINEAR array to encoder (NOT the tiled one!)
-	InputFrame->SetTexture(LinearArray, AVEncoder::FVideoEncoderInputFrame::EUnderlyingRHI::Vulkan, nullptr,
-		[](CUarray) { /* No-op: Cache owns the resources, will be cleaned up in ClearCUDATextureCache() */ });
-
-	return true;
-#else
-	OutErrorMessage = TEXT("CUDA interop only supported on Linux");
-	return false;
-#endif
-}
-
-//----------------------------------------------------------
-// Encoding Operations
-//----------------------------------------------------------
 
 bool FHardwareEncoderWrapper::EncodeFrame(FRHITexture* Texture, uint64 FrameNumber, bool bForceKeyframe)
 {
-	if (!bInitialized || bShuttingDown || !VideoEncoder.IsValid() || !VideoEncoderInput.IsValid())
+	if (!bInitialized || bShuttingDown || !AVCodecEncoder || !Texture || !Texture->IsValid())
 	{
 		EncodingFailureCount++;
 		return false;
 	}
 
-	if (!Texture || !Texture->IsValid())
+	FTextureRHIRef TextureRef(Texture);
+	const bool bForce = bForceKeyframe || bForceNextKeyframe.exchange(false);
+	const double TimestampUs = FPlatformTime::Seconds() * 1000000.0;
+	const bool bOk = AVCodecEncoder->SendFrame(TextureRef, TimestampUs, bForce);
+	if (!bOk)
 	{
-		UE_LOG(LogTemp, Warning, TEXT("HardwareEncoderWrapper: Invalid texture"));
 		EncodingFailureCount++;
 		return false;
 	}
-
-	// Get RHI type once (used for D3D12 workaround and texture setting)
-	const ERHIInterfaceType RHIType = RHIGetInterfaceType();
-
-	// WINDOWS D3D12 WORKAROUND:
-	// UE5.1 has a bug where pooled input frames don't clear D3D12.Texture on reuse,
-	// causing check(D3D12.Texture == nullptr) assertion failure at VideoEncoderInput.cpp:879.
-	// Workaround: Flush the input pool before obtaining a frame to force creation of new frames.
-	// This is less efficient but necessary for correctness on Windows D3D12 + NVENC.
-#if PLATFORM_WINDOWS
-	if (RHIType == ERHIInterfaceType::D3D12)
-	{
-		// Flush to discard any pooled frames that have stale D3D12.Texture pointers
-		VideoEncoderInput->Flush();
-	}
-#endif
-
-	// Obtain input frame from VideoEncoderInput
-	TSharedPtr<AVEncoder::FVideoEncoderInputFrame> InputFrame = VideoEncoderInput->ObtainInputFrame();
-	if (!InputFrame.IsValid())
-	{
-		UE_LOG(LogTemp, Warning, TEXT("HardwareEncoderWrapper: Failed to obtain input frame"));
-		EncodingFailureCount++;
-		return false;
-	}
-
-	// Return frame to encoder input on failure paths before Encode()
-	auto ReleaseInputFrame = [&InputFrame]()
-	{
-		if (InputFrame.IsValid())
-		{
-			InputFrame->Release();
-			InputFrame.Reset();
-		}
-	};
-
-	// Set frame dimensions
-	InputFrame->SetWidth(Config.Width);
-	InputFrame->SetHeight(Config.Height);
-
-	// Set timestamp and frame ID
-	InputFrame->SetTimestampUs(FPlatformTime::Seconds() * 1000000.0);
-	InputFrame->SetFrameID(FrameNumber);
-
-	// Set texture based on RHI type and encoding mode
-	// Note: RHIType already declared above for D3D12 workaround
-	bool bTextureSet = false;
-#if PLATFORM_WINDOWS
-	if (RHIType == ERHIInterfaceType::D3D11)
-	{
-		ID3D11Texture2D* D3D11Texture = static_cast<ID3D11Texture2D*>(Texture->GetNativeResource());
-		InputFrame->SetTexture(D3D11Texture, [](ID3D11Texture2D*){ /* Texture release callback */ });
-		bTextureSet = true;
-	}
-	else if (RHIType == ERHIInterfaceType::D3D12)
-	{
-		ID3D12Resource* D3D12Resource = static_cast<ID3D12Resource*>(Texture->GetNativeResource());
-		InputFrame->SetTexture(D3D12Resource, [](ID3D12Resource*){ /* Texture release callback */ });
-		bTextureSet = true;
-	}
-	else if (RHIType == ERHIInterfaceType::Vulkan)
-	{
-		// Windows Vulkan texture handling
-		VkImage VulkanImage = static_cast<VkImage>(Texture->GetNativeResource());
-		InputFrame->SetTexture(VulkanImage, [](VkImage){ /* Texture release callback */ });
-		bTextureSet = true;
-	}
-#elif PLATFORM_LINUX
-	if (RHIType == ERHIInterfaceType::Vulkan)
-	{
-		if (bUseCUDAMode)
-		{
-			FString InteropError;
-			if (!SetCUDATextureFromVulkan(Texture, InputFrame, InteropError))
-			{
-				UE_LOG(LogTemp, Error, TEXT("HardwareEncoderWrapper: CUDA/Vulkan interop failed: %s"), *InteropError);
-				EncodingFailureCount++;
-				ReleaseInputFrame();
-				return false;
-			}
-			bTextureSet = true;
-		}
-		else
-		{
-			// AMF mode: Direct Vulkan path
-			VkImage VulkanImage = static_cast<VkImage>(Texture->GetNativeResource());
-			InputFrame->SetTexture(VulkanImage, [](VkImage){ /* Texture release callback */ });
-			bTextureSet = true;
-		}
-	}
-#endif
-
-	if (!bTextureSet)
-	{
-		UE_LOG(LogTemp, Warning, TEXT("HardwareEncoderWrapper: Unsupported RHI for SetTexture: %d"), (int32)RHIType);
-		EncodingFailureCount++;
-		ReleaseInputFrame();
-		return false;
-	}
-
-	// Prepare encode options
-	AVEncoder::FVideoEncoder::FEncodeOptions EncodeOptions;
-	EncodeOptions.bForceKeyFrame = bForceKeyframe || bForceNextKeyframe.exchange(false);
-
-	// CRITICAL: Final shutdown check right before Encode()
-	// Shutdown may have started between the initial check and here
-	if (bShuttingDown.load() || !VideoEncoder.IsValid())
-	{
-		ReleaseInputFrame();
-		return false;
-	}
-
-	// Submit frame to encoder
-	VideoEncoder->Encode(InputFrame, EncodeOptions);
 
 	CurrentFrameNumber = FrameNumber;
 	LastEncodeTime = FPlatformTime::Seconds();
 	TotalFramesEncoded++;
-
 	return true;
 }
 
 bool FHardwareEncoderWrapper::GetEncodedData(TArray<FEncodedNALUnit>& OutNALUnits)
 {
-	FScopeLock Lock(&NALQueueMutex);
-
 	OutNALUnits.Empty();
-
-	// Drain all available NAL units from queue
-	FEncodedNALUnit NALUnit;
-	while (NALOutputQueue.Dequeue(NALUnit))
+	if (!AVCodecEncoder || bShuttingDown)
 	{
-		// CRITICAL: Validate NAL data integrity after dequeue
-		// Detects memory corruption from encoder callback issues
-		const uint8* DataPtr = NALUnit.Data.GetData();
-		const int32 DataSize = NALUnit.Data.Num();
-
-		if (DataSize > 0 && (DataPtr == nullptr || reinterpret_cast<uintptr_t>(DataPtr) == ~static_cast<uintptr_t>(0)))
-		{
-			UE_LOG(LogTemp, Error, TEXT("HardwareEncoderWrapper: Corrupted NAL from queue (Ptr=0x%p, Size=%d) - encoder callback may have produced invalid data"),
-				DataPtr, DataSize);
-			continue; // Skip corrupted NAL
-		}
-
-		OutNALUnits.Add(MoveTemp(NALUnit));
+		return false;
 	}
 
+	TArray<FSimpleVideoPacket> Packets;
+	AVCodecEncoder->ReceivePackets(Packets);
+	for (FSimpleVideoPacket& Packet : Packets)
+	{
+		const uint8* Data = Packet.RawPacket.DataPtr.Get();
+		const uint32 Size = Packet.RawPacket.DataSize;
+		if (!Data || Size == 0)
+		{
+			continue;
+		}
+
+		TotalBytesOutput += Size;
+		if (Packet.RawPacket.bIsKeyframe)
+		{
+			TotalKeyframesEncoded++;
+		}
+
+		TArray<FEncodedNALUnit> Parsed;
+		ParseNALUnits(Data, Size, Parsed);
+		if (Parsed.Num() == 0)
+		{
+			FEncodedNALUnit NAL;
+			NAL.Data.Append(Data, Size);
+			NAL.NALType = ExtractNALType(Data, Size);
+			Parsed.Add(MoveTemp(NAL));
+		}
+
+		for (FEncodedNALUnit& NAL : Parsed)
+		{
+			NAL.bIsKeyframe = Packet.RawPacket.bIsKeyframe;
+			NAL.TimestampMs = static_cast<uint64>(Packet.RawPacket.Timestamp / 1000);
+			NAL.FrameNumber = CurrentFrameNumber.load();
+			OutNALUnits.Add(MoveTemp(NAL));
+		}
+	}
 	return OutNALUnits.Num() > 0;
 }
 
 void FHardwareEncoderWrapper::ForceKeyframe()
 {
 	bForceNextKeyframe = true;
-	UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Next frame will be keyframe"));
 }
 
-//----------------------------------------------------------
-// Encoder Callbacks
-//----------------------------------------------------------
-
-void FHardwareEncoderWrapper::OnEncodedFrame(uint32 LayerIndex, const TSharedPtr<AVEncoder::FVideoEncoderInputFrame> Frame, const AVEncoder::FCodecPacket& Packet)
+void FHardwareEncoderWrapper::ParseNALUnits(const uint8* Data, uint32 Size, TArray<FEncodedNALUnit>& OutNALs)
 {
-	// CRITICAL: Check shutdown flag first - encoder may call this callback during shutdown
-	if (bShuttingDown.load())
+	OutNALs.Empty();
+	if (!Data || Size < 4)
 	{
 		return;
 	}
-
-	if (!Frame.IsValid())
+	for (uint32 I = 0; I + 3 < Size; )
 	{
-		return;
-	}
-
-	// Check if we have data
-	if (Packet.DataSize == 0 || !Packet.Data.IsValid())
-	{
-		return;
-	}
-
-	// CRITICAL: Validate actual data pointer before use
-	// During shutdown, the pointer may be invalid (0xFFFFFFFFFFFFFFFF)
-	const uint8* PacketDataPtr = Packet.Data.Get();
-	if (PacketDataPtr == nullptr || reinterpret_cast<uintptr_t>(PacketDataPtr) == ~static_cast<uintptr_t>(0))
-	{
-		UE_LOG(LogTemp, Warning, TEXT("HardwareEncoderWrapper: Invalid packet data pointer (0x%p) - skipping"), PacketDataPtr);
-		return;
-	}
-
-	// Double-check shutdown flag after validation (may have changed)
-	if (bShuttingDown.load())
-	{
-		return;
-	}
-
-	// Update statistics
-	TotalBytesOutput += Packet.DataSize;
-	if (Packet.IsKeyFrame)
-	{
-		TotalKeyframesEncoded++;
-	}
-
-	// Parse bitstream into NAL units
-	TArray<FEncodedNALUnit> NALUnits;
-	ParseNALUnits(PacketDataPtr, Packet.DataSize, NALUnits);
-
-	// Check shutdown again after parsing (may have started during parse)
-	if (bShuttingDown.load())
-	{
-		return;
-	}
-
-	// Enqueue NAL units for retrieval
-	FScopeLock Lock(&NALQueueMutex);
-	for (FEncodedNALUnit& NALUnit : NALUnits)
-	{
-		// CRITICAL: Validate NAL data before enqueue
-		// If corrupted here, the problem is in ParseNALUnits or encoder output
-		const uint8* DataPtr = NALUnit.Data.GetData();
-		const int32 DataSize = NALUnit.Data.Num();
-
-		if (DataSize > 0 && (DataPtr == nullptr || reinterpret_cast<uintptr_t>(DataPtr) == ~static_cast<uintptr_t>(0)))
+		uint32 StartCode = 0;
+		if (I + 4 <= Size && Data[I] == 0 && Data[I + 1] == 0 && Data[I + 2] == 0 && Data[I + 3] == 1)
+			StartCode = 4;
+		else if (Data[I] == 0 && Data[I + 1] == 0 && Data[I + 2] == 1)
+			StartCode = 3;
+		if (!StartCode)
 		{
-			UE_LOG(LogTemp, Error, TEXT("HardwareEncoderWrapper: ParseNALUnits produced corrupted NAL (Ptr=0x%p, Size=%d) - encoder output may be invalid"),
-				DataPtr, DataSize);
+			++I;
 			continue;
 		}
-
-		NALUnit.TimestampMs = Frame->GetTimestampUs() / 1000;
-		NALUnit.FrameNumber = CurrentFrameNumber;
-		NALUnit.bIsKeyframe = Packet.IsKeyFrame;
-
-		NALOutputQueue.Enqueue(MoveTemp(NALUnit));
-	}
-
-	// Release the input frame
-	Frame->Release();
-}
-
-//----------------------------------------------------------
-// NAL Unit Processing
-//----------------------------------------------------------
-
-void FHardwareEncoderWrapper::ParseNALUnits(const uint8* BitstreamData, uint32 BitstreamSize, TArray<FEncodedNALUnit>& OutNALUnits)
-{
-	OutNALUnits.Empty();
-
-	// H.264 NAL units are separated by start codes: 0x00 0x00 0x00 0x01 (4 bytes)
-	// or 0x00 0x00 0x01 (3 bytes)
-
-	uint32 Index = 0;
-
-	while (Index < BitstreamSize - 4)
-	{
-		// Find start code
-		bool bFoundStartCode = false;
-		uint32 StartCodeSize = 0;
-
-		// Check for 4-byte start code (0x00 0x00 0x00 0x01)
-		if (BitstreamData[Index] == 0x00 && BitstreamData[Index + 1] == 0x00 &&
-			BitstreamData[Index + 2] == 0x00 && BitstreamData[Index + 3] == 0x01)
+		uint32 J = I + StartCode;
+		while (J + 3 < Size)
 		{
-			bFoundStartCode = true;
-			StartCodeSize = 4;
+			const bool bStart4 = J + 4 <= Size && Data[J] == 0 && Data[J + 1] == 0 && Data[J + 2] == 0 && Data[J + 3] == 1;
+			const bool bStart3 = Data[J] == 0 && Data[J + 1] == 0 && Data[J + 2] == 1;
+			if (bStart4 || bStart3) break;
+			++J;
 		}
-		// Check for 3-byte start code (0x00 0x00 0x01)
-		else if (BitstreamData[Index] == 0x00 && BitstreamData[Index + 1] == 0x00 &&
-				 BitstreamData[Index + 2] == 0x01)
+		if (J + 3 >= Size) J = Size;
+		const uint32 NALSize = J - I;
+		if (NALSize > StartCode)
 		{
-			bFoundStartCode = true;
-			StartCodeSize = 3;
+			FEncodedNALUnit NAL;
+			NAL.Data.Append(Data + I, NALSize);
+			NAL.NALType = ExtractNALType(Data + I + StartCode, NALSize - StartCode);
+			OutNALs.Add(MoveTemp(NAL));
 		}
-
-		if (!bFoundStartCode)
-		{
-			Index++;
-			continue;
-		}
-
-		// Find next start code to determine NAL unit size
-		uint32 NextStartCode = Index + StartCodeSize;
-		while (NextStartCode < BitstreamSize - 4)
-		{
-			if ((BitstreamData[NextStartCode] == 0x00 && BitstreamData[NextStartCode + 1] == 0x00 &&
-				 BitstreamData[NextStartCode + 2] == 0x00 && BitstreamData[NextStartCode + 3] == 0x01) ||
-				(BitstreamData[NextStartCode] == 0x00 && BitstreamData[NextStartCode + 1] == 0x00 &&
-				 BitstreamData[NextStartCode + 2] == 0x01))
-			{
-				break; // Found next start code
-			}
-			NextStartCode++;
-		}
-
-		// If we didn't find another start code, this is the last NAL unit
-		if (NextStartCode >= BitstreamSize - 4)
-		{
-			NextStartCode = BitstreamSize;
-		}
-
-		// Extract NAL unit
-		const uint32 NALSize = NextStartCode - Index;
-		if (NALSize > StartCodeSize)
-		{
-			FEncodedNALUnit NALUnit;
-			NALUnit.Data.Append(&BitstreamData[Index], NALSize);
-			NALUnit.NALType = ExtractNALType(&BitstreamData[Index + StartCodeSize], NALSize - StartCodeSize);
-
-			OutNALUnits.Add(MoveTemp(NALUnit));
-		}
-
-		Index = NextStartCode;
+		I = J;
 	}
 }
 
 uint8 FHardwareEncoderWrapper::ExtractNALType(const uint8* Data, uint32 Size) const
 {
-	if (!Data || Size < 1)
-	{
-		return 0;
-	}
-
-	// NAL unit type is in lower 5 bits of first byte
-	// Byte format: forbidden_zero_bit(1) + nal_ref_idc(2) + nal_unit_type(5)
-	return Data[0] & 0x1F;
+	return Data && Size ? (Data[0] & 0x1F) : 0;
 }
-
-//----------------------------------------------------------
-// Statistics
-//----------------------------------------------------------
 
 FString FHardwareEncoderWrapper::GetStatsString() const
 {
-	const double CurrentTime = FPlatformTime::Seconds();
-	const double TimeSinceLastEncode = CurrentTime - LastEncodeTime;
-
-	return FString::Printf(
-		TEXT("HardwareEncoder (%s): Encoded=%llu frames (%llu keyframes), Output=%.2f MB, Failures=%llu, LastEncode=%.3fs ago"),
-		*EncoderTypeToString(EncoderType),
-		TotalFramesEncoded.load(),
-		TotalKeyframesEncoded.load(),
-		TotalBytesOutput.load() / (1024.0 * 1024.0),
-		EncodingFailureCount.load(),
-		TimeSinceLastEncode
-	);
+	return FString::Printf(TEXT("HardwareEncoder (VideoToolbox): Encoded=%llu frames (%llu keyframes), Output=%.2f MB, Failures=%llu"),
+		TotalFramesEncoded.load(), TotalKeyframesEncoded.load(),
+		TotalBytesOutput.load() / (1024.0 * 1024.0), EncodingFailureCount.load());
 }
+
+#endif // PLATFORM_MAC

--- a/Source/RealGazeboStreaming/Private/Encoder/HardwareEncoderWrapper.cpp
+++ b/Source/RealGazeboStreaming/Private/Encoder/HardwareEncoderWrapper.cpp
@@ -1,10 +1,7 @@
 // Copyright (c) 2024-2025 SUV Lab, Chungbuk National University
 // Licensed under the GNU General Public License v3.0.
 
-#if !PLATFORM_MAC
-// Preserve the current upstream Windows/Linux implementation byte-for-byte.
-#include "HardwareEncoderWrapper.upstream.inc"
-#else
+#if PLATFORM_MAC
 
 #include "Encoder/HardwareEncoderWrapper.h"
 #include "HAL/PlatformTime.h"
@@ -99,8 +96,6 @@ bool FHardwareEncoderWrapper::CreateHardwareEncoder(FString& OutErrorMessage)
 		return false;
 	}
 
-	// EEncoderType currently models NVENC/AMF only; keep Unknown rather than
-	// misreporting the backend until the public enum is extended upstream.
 	EncoderType = EEncoderType::Unknown;
 	return true;
 }
@@ -121,8 +116,7 @@ bool FHardwareEncoderWrapper::EncodeFrame(FRHITexture* Texture, uint64 FrameNumb
 	FTextureRHIRef TextureRef(Texture);
 	const bool bForce = bForceKeyframe || bForceNextKeyframe.exchange(false);
 	const double TimestampUs = FPlatformTime::Seconds() * 1000000.0;
-	const bool bOk = AVCodecEncoder->SendFrame(TextureRef, TimestampUs, bForce);
-	if (!bOk)
+	if (!AVCodecEncoder->SendFrame(TextureRef, TimestampUs, bForce))
 	{
 		EncodingFailureCount++;
 		return false;
@@ -192,27 +186,40 @@ void FHardwareEncoderWrapper::ParseNALUnits(const uint8* Data, uint32 Size, TArr
 	{
 		return;
 	}
+
 	for (uint32 I = 0; I + 3 < Size; )
 	{
 		uint32 StartCode = 0;
 		if (I + 4 <= Size && Data[I] == 0 && Data[I + 1] == 0 && Data[I + 2] == 0 && Data[I + 3] == 1)
+		{
 			StartCode = 4;
+		}
 		else if (Data[I] == 0 && Data[I + 1] == 0 && Data[I + 2] == 1)
+		{
 			StartCode = 3;
+		}
 		if (!StartCode)
 		{
 			++I;
 			continue;
 		}
+
 		uint32 J = I + StartCode;
 		while (J + 3 < Size)
 		{
 			const bool bStart4 = J + 4 <= Size && Data[J] == 0 && Data[J + 1] == 0 && Data[J + 2] == 0 && Data[J + 3] == 1;
 			const bool bStart3 = Data[J] == 0 && Data[J + 1] == 0 && Data[J + 2] == 1;
-			if (bStart4 || bStart3) break;
+			if (bStart4 || bStart3)
+			{
+				break;
+			}
 			++J;
 		}
-		if (J + 3 >= Size) J = Size;
+		if (J + 3 >= Size)
+		{
+			J = Size;
+		}
+
 		const uint32 NALSize = J - I;
 		if (NALSize > StartCode)
 		{
@@ -232,9 +239,12 @@ uint8 FHardwareEncoderWrapper::ExtractNALType(const uint8* Data, uint32 Size) co
 
 FString FHardwareEncoderWrapper::GetStatsString() const
 {
-	return FString::Printf(TEXT("HardwareEncoder (VideoToolbox): Encoded=%llu frames (%llu keyframes), Output=%.2f MB, Failures=%llu"),
-		TotalFramesEncoded.load(), TotalKeyframesEncoded.load(),
-		TotalBytesOutput.load() / (1024.0 * 1024.0), EncodingFailureCount.load());
+	return FString::Printf(
+		TEXT("HardwareEncoder (VideoToolbox): Encoded=%llu frames (%llu keyframes), Output=%.2f MB, Failures=%llu"),
+		TotalFramesEncoded.load(),
+		TotalKeyframesEncoded.load(),
+		TotalBytesOutput.load() / (1024.0 * 1024.0),
+		EncodingFailureCount.load());
 }
 
 #endif // PLATFORM_MAC

--- a/Source/RealGazeboStreaming/Private/Encoder/HardwareEncoderWrapper.upstream.inc
+++ b/Source/RealGazeboStreaming/Private/Encoder/HardwareEncoderWrapper.upstream.inc
@@ -1,0 +1,1 @@
+// Placeholder preserving upstream encoder source is created in the next commit.

--- a/Source/RealGazeboStreaming/Private/Encoder/HardwareEncoderWrapper.upstream.inc
+++ b/Source/RealGazeboStreaming/Private/Encoder/HardwareEncoderWrapper.upstream.inc
@@ -1,1 +1,1050 @@
-// Placeholder preserving upstream encoder source is created in the next commit.
+// Copyright (c) 2024-2025 SUV Lab, Chungbuk National University
+// Author    : Gonapinuwala Lahiru Sandaruwan
+// Supervisor: Prof. SungTae Moon - Project lead & research supervision
+// Licensed under the GNU General Public License v3.0.
+// See LICENSE file in the project root for full license information.
+
+#include "Encoder/HardwareEncoderWrapper.h"
+#include "VideoEncoder.h"
+#include "VideoEncoderFactory.h"
+#include "VideoEncoderCommon.h"
+#include "VideoEncoderInput.h"
+#include "CodecPacket.h"
+#include "HAL/PlatformTime.h"
+#include "Modules/ModuleManager.h"
+#include "RHI.h"
+#include "RHIResources.h"
+#include "CudaModule.h"
+
+// Vulkan RHI interface for both Windows and Linux
+#if PLATFORM_LINUX || PLATFORM_WINDOWS
+#include "IVulkanDynamicRHI.h"
+#endif
+
+#if PLATFORM_LINUX
+#include <unistd.h>
+#endif
+
+// CUDA support for NVENC on Linux is included above (line 17)
+
+//----------------------------------------------------------
+// Construction & Initialization
+//----------------------------------------------------------
+
+FHardwareEncoderWrapper::FHardwareEncoderWrapper()
+{
+	UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Created"));
+}
+
+FHardwareEncoderWrapper::~FHardwareEncoderWrapper()
+{
+	Shutdown();
+}
+
+bool FHardwareEncoderWrapper::Initialize(const FEncoderConfig& InConfig, FString& OutErrorMessage)
+{
+	if (bInitialized)
+	{
+		OutErrorMessage = TEXT("Encoder already initialized");
+		return true;
+	}
+
+	UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Initializing..."));
+	UE_LOG(LogTemp, Log, TEXT("  Config: %s"), *InConfig.ToString());
+
+	// Validate configuration
+	if (!InConfig.Validate(OutErrorMessage))
+	{
+		UE_LOG(LogTemp, Error, TEXT("HardwareEncoderWrapper: Invalid config - %s"), *OutErrorMessage);
+		return false;
+	}
+
+	Config = InConfig;
+
+	// Create hardware encoder (NVENC or AMF)
+	if (!CreateHardwareEncoder(OutErrorMessage))
+	{
+		UE_LOG(LogTemp, Error, TEXT("HardwareEncoderWrapper: Failed to create encoder - %s"), *OutErrorMessage);
+		return false;
+	}
+
+	// Register callbacks
+	RegisterEncoderCallbacks();
+
+	bInitialized = true;
+	UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Initialized successfully (%s)"),
+		*EncoderTypeToString(EncoderType));
+
+	return true;
+}
+
+void FHardwareEncoderWrapper::Shutdown()
+{
+	if (!bInitialized)
+	{
+		return;
+	}
+
+	const uint64 FramesEncoded = TotalFramesEncoded.load();
+	UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Shutting down... (Encoded %llu frames)"), FramesEncoded);
+	bShuttingDown = true;
+
+	// Flush input first to complete pending operations
+	if (VideoEncoderInput)
+	{
+		VideoEncoderInput->Flush();
+	}
+
+	// WORKAROUND: UE5 NVENC bug - Shutdown() crashes if no frames were encoded
+	// because internal buffers were never allocated
+	if (FramesEncoded > 0)
+	{
+		// Frames were encoded - safe to shutdown normally
+		FPlatformProcess::Sleep(0.05f);
+
+		if (VideoEncoder)
+		{
+			VideoEncoder->Shutdown();
+			VideoEncoder.Reset();
+		}
+		if (VideoEncoderInput)
+		{
+			VideoEncoderInput.Reset();
+		}
+	}
+	else
+	{
+		// No frames encoded - NVENC internal buffers not allocated
+		// Must prevent destructor from running (it calls Shutdown which crashes)
+		// Store in static array to keep alive (intentional leak for stability)
+		UE_LOG(LogTemp, Warning, TEXT("HardwareEncoderWrapper: No frames encoded - leaking NVENC to prevent crash"));
+		static TArray<TUniquePtr<AVEncoder::FVideoEncoder>> LeakedEncoders;
+		static TArray<TSharedPtr<AVEncoder::FVideoEncoderInput>> LeakedInputs;
+		if (VideoEncoder)
+		{
+			LeakedEncoders.Add(MoveTemp(VideoEncoder));
+		}
+		if (VideoEncoderInput)
+		{
+			LeakedInputs.Add(VideoEncoderInput);
+			VideoEncoderInput.Reset();
+		}
+	}
+
+	// Clear CUDA texture cache (releases cached CUarrays)
+	ClearCUDATextureCache();
+
+	bInitialized = false;
+	bShuttingDown = false;
+
+	UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Shutdown complete (Encoded: %llu frames, %llu keyframes, %.2f MB)"),
+		FramesEncoded,
+		TotalKeyframesEncoded.load(),
+		TotalBytesOutput.load() / (1024.0 * 1024.0));
+}
+
+//----------------------------------------------------------
+// Internal Initialization
+//----------------------------------------------------------
+
+bool FHardwareEncoderWrapper::CreateHardwareEncoder(FString& OutErrorMessage)
+{
+	// Step 1: Create VideoEncoderInput based on RHI type
+	if (!GDynamicRHI)
+	{
+		OutErrorMessage = TEXT("RHI not initialized");
+		return false;
+	}
+
+	const ERHIInterfaceType RHIType = RHIGetInterfaceType();
+
+#if PLATFORM_WINDOWS
+	if (RHIType == ERHIInterfaceType::D3D11)
+	{
+		VideoEncoderInput = AVEncoder::FVideoEncoderInput::CreateForD3D11(
+			GDynamicRHI->RHIGetNativeDevice(),
+			true,  // IsResizable
+			IsRHIDeviceAMD()  // IsShared (for AMD compatibility)
+		);
+	}
+	else if (RHIType == ERHIInterfaceType::D3D12)
+	{
+		// IMPORTANT: On Windows D3D12 with NVIDIA GPUs, NVENC requires a D3D11 device
+		// for encoding. This means we MUST use IsShared=true to create a D3D11 intermediate
+		// device that NVENC can use.
+		//
+		// UE5.1 BUG WORKAROUND:
+		// When IsShared=true, there's a bug where pooled input frames don't properly clear
+		// D3D12.Texture before reuse, causing check(D3D12.Texture == nullptr) to fail.
+		//
+		// Solution: Use IsShared=true (required for NVENC) and set MaxNumBuffers=1 to
+		// prevent frame pooling/reuse. Each encoding will create a new frame, avoiding
+		// the assertion failure.
+		VideoEncoderInput = AVEncoder::FVideoEncoderInput::CreateForD3D12(
+			GDynamicRHI->RHIGetNativeDevice(),
+			true,  // IsResizable
+			true   // IsShared - MUST be true for NVENC (needs D3D11 device)
+		);
+
+		// CRITICAL: Set MaxNumBuffers=1 to prevent frame reuse bug
+		// This avoids the check(D3D12.Texture == nullptr) assertion failure
+		if (VideoEncoderInput.IsValid())
+		{
+			VideoEncoderInput->SetMaxNumBuffers(1);
+			UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: D3D12 shared mode with MaxNumBuffers=1 (NVENC workaround)"));
+		}
+	}
+	else if (RHIType == ERHIInterfaceType::Vulkan)
+	{
+		// Windows Vulkan support
+		IVulkanDynamicRHI* VulkanRHI = GetIVulkanDynamicRHI();
+		if (!VulkanRHI)
+		{
+			OutErrorMessage = TEXT("Failed to get Vulkan RHI interface on Windows");
+			return false;
+		}
+
+		AVEncoder::FVulkanDataStruct VulkanData;
+		VulkanData.VulkanInstance = VulkanRHI->RHIGetVkInstance();
+		VulkanData.VulkanPhysicalDevice = VulkanRHI->RHIGetVkPhysicalDevice();
+		VulkanData.VulkanDevice = VulkanRHI->RHIGetVkDevice();
+
+		UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Windows Vulkan - Instance=%p, PhysicalDevice=%p, Device=%p"),
+			VulkanData.VulkanInstance, VulkanData.VulkanPhysicalDevice, VulkanData.VulkanDevice);
+
+		VideoEncoderInput = AVEncoder::FVideoEncoderInput::CreateForVulkan(
+			&VulkanData,
+			true  // IsResizable
+		);
+	}
+	else
+#elif PLATFORM_LINUX
+	if (RHIType == ERHIInterfaceType::Vulkan)
+	{
+		// On Linux with NVIDIA GPU, NVENC doesn't support Vulkan textures directly.
+		// We must use CUDA instead. Check if CUDA module is available.
+		UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Linux Vulkan detected, checking for CUDA..."));
+
+		FCUDAModule* CudaModule = FModuleManager::GetModulePtr<FCUDAModule>("CUDA");
+		UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: CUDA module ptr = %p"), CudaModule);
+
+		if (CudaModule)
+		{
+			const bool bCudaAvailable = CudaModule->IsAvailable();
+			UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: CUDA IsAvailable() = %s"), bCudaAvailable ? TEXT("true") : TEXT("false"));
+
+			if (bCudaAvailable)
+			{
+				// NVIDIA GPU detected - use CUDA for NVENC (NVENC supports CUDA_R8G8B8A8_UNORM)
+				CUcontext LocalCudaContext = CudaModule->GetCudaContext();
+				UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: CUDA context = %p"), LocalCudaContext);
+
+				if (LocalCudaContext)
+				{
+					UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Using CUDA for NVENC encoding (CudaContext=%p)"), LocalCudaContext);
+
+					VideoEncoderInput = AVEncoder::FVideoEncoderInput::CreateForCUDA(
+						LocalCudaContext,
+						true  // IsResizable
+					);
+
+					if (VideoEncoderInput.IsValid())
+					{
+						bUseCUDAMode = true;
+						CudaContext = LocalCudaContext;
+						UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: CUDA encoder input created successfully"));
+					}
+					else
+					{
+						UE_LOG(LogTemp, Warning, TEXT("HardwareEncoderWrapper: CreateForCUDA failed - falling back to Vulkan"));
+					}
+				}
+				else
+				{
+					UE_LOG(LogTemp, Warning, TEXT("HardwareEncoderWrapper: CUDA available but no context - falling back to Vulkan"));
+				}
+			}
+		}
+		else
+		{
+			UE_LOG(LogTemp, Warning, TEXT("HardwareEncoderWrapper: CUDA module not loaded - using Vulkan"));
+		}
+
+		// Fallback to Vulkan if CUDA failed (for AMD GPUs which support Vulkan via AMF)
+		if (!VideoEncoderInput.IsValid())
+		{
+			IVulkanDynamicRHI* VulkanRHI = GetIVulkanDynamicRHI();
+			if (!VulkanRHI)
+			{
+				OutErrorMessage = TEXT("Failed to get Vulkan RHI interface");
+				return false;
+			}
+
+			AVEncoder::FVulkanDataStruct VulkanData;
+			VulkanData.VulkanInstance = VulkanRHI->RHIGetVkInstance();
+			VulkanData.VulkanPhysicalDevice = VulkanRHI->RHIGetVkPhysicalDevice();
+			VulkanData.VulkanDevice = VulkanRHI->RHIGetVkDevice();
+
+			UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Using Vulkan for AMF encoding - Instance=%p, PhysicalDevice=%p, Device=%p"),
+				VulkanData.VulkanInstance, VulkanData.VulkanPhysicalDevice, VulkanData.VulkanDevice);
+
+			VideoEncoderInput = AVEncoder::FVideoEncoderInput::CreateForVulkan(
+				&VulkanData,
+				true  // IsResizable
+			);
+		}
+	}
+	else
+#endif
+	{
+		OutErrorMessage = FString::Printf(TEXT("Unsupported RHI type for encoding: %d"), (int32)RHIType);
+		return false;
+	}
+
+	if (!VideoEncoderInput.IsValid())
+	{
+		OutErrorMessage = TEXT("Failed to create VideoEncoderInput");
+		return false;
+	}
+
+	// Step 2: Build FLayerConfig with ALL configuration settings
+	AVEncoder::FVideoEncoder::FLayerConfig LayerConfig;
+	LayerConfig.Width = Config.Width;
+	LayerConfig.Height = Config.Height;
+	LayerConfig.MaxFramerate = Config.FrameRate;
+	LayerConfig.TargetBitrate = Config.Bitrate;
+	LayerConfig.MaxBitrate = Config.Bitrate * 1.2;  // Allow 20% overshoot
+
+	// Ultra-low latency settings
+	LayerConfig.H264Profile = Config.GetAVEncoderProfile();
+	LayerConfig.RateControlMode = Config.GetRateControlMode();
+	LayerConfig.MultipassMode = Config.GetMultipassMode();
+
+	// GOP and frame structure (critical for low latency!)
+	LayerConfig.QPMin = -1;  // Let encoder decide
+	LayerConfig.QPMax = -1;  // Let encoder decide
+
+	// Step 3: Get available encoders and create the best match
+	const TArray<AVEncoder::FVideoEncoderInfo>& AvailableEncoders =
+		AVEncoder::FVideoEncoderFactory::Get().GetAvailable();
+
+	if (AvailableEncoders.Num() == 0)
+	{
+		OutErrorMessage = TEXT("No video encoders available. Check HardwareEncoders plugin.");
+		return false;
+	}
+
+	// Try to find and create H.264 encoder (prefer NVENC, fallback to AMF)
+	for (const AVEncoder::FVideoEncoderInfo& EncoderInfo : AvailableEncoders)
+	{
+		if (EncoderInfo.CodecType == AVEncoder::ECodecType::H264)
+		{
+			// Try to create encoder
+			VideoEncoder = AVEncoder::FVideoEncoderFactory::Get().Create(
+				EncoderInfo.ID,
+				VideoEncoderInput,
+				LayerConfig
+			);
+
+			if (VideoEncoder.IsValid())
+			{
+				// Detect encoder type from ID
+				if (EncoderInfo.ID == 0)  // NVENC usually ID 0
+				{
+					EncoderType = EEncoderType::NVENC;
+					UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Created NVENC encoder"));
+				}
+				else if (EncoderInfo.ID == 1)  // AMF usually ID 1
+				{
+					EncoderType = EEncoderType::AMF;
+					UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Created AMF encoder"));
+				}
+				else
+				{
+					EncoderType = EEncoderType::Unknown;
+					UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Created H264 encoder (ID=%d)"), EncoderInfo.ID);
+				}
+
+				// Successfully created encoder - break loop
+				break;
+			}
+		}
+	}
+
+	if (!VideoEncoder.IsValid())
+	{
+		OutErrorMessage = TEXT("No H264 hardware encoder available (NVENC or AMF). Check GPU drivers and HardwareEncoders plugin.");
+		EncoderType = EEncoderType::Unknown;
+		return false;
+	}
+
+	return true;
+}
+
+void FHardwareEncoderWrapper::RegisterEncoderCallbacks()
+{
+	if (!VideoEncoder.IsValid())
+	{
+		return;
+	}
+
+	// Register output callback - called when encoder produces data
+	// UE 5.1 signature: void(uint32 LayerIndex, const TSharedPtr<FVideoEncoderInputFrame> Frame, const FCodecPacket& Packet)
+	VideoEncoder->SetOnEncodedPacket([this](uint32 LayerIndex, const TSharedPtr<AVEncoder::FVideoEncoderInputFrame> Frame, const AVEncoder::FCodecPacket& Packet)
+	{
+		OnEncodedFrame(LayerIndex, Frame, Packet);
+	});
+}
+
+//----------------------------------------------------------
+// CUDA/Vulkan Interop (Linux, NVIDIA) - WITH CACHING
+//----------------------------------------------------------
+
+void FHardwareEncoderWrapper::ClearCUDATextureCache()
+{
+#if PLATFORM_LINUX
+	FScopeLock Lock(&CUDACacheMutex);
+
+	if (CUDATextureCache.Num() == 0)
+	{
+		return;
+	}
+
+	UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Clearing CUDA texture cache (%d entries)"), CUDATextureCache.Num());
+
+	if (CudaContext)
+	{
+		FCUDAModule::CUDA().cuCtxPushCurrent(CudaContext);
+
+		for (auto& Pair : CUDATextureCache)
+		{
+			FCachedCUDATexture& Cached = Pair.Value;
+			if (Cached.bValid)
+			{
+				// Destroy linear staging array first (created via cuArrayCreate)
+				if (Cached.LinearArray)
+				{
+					FCUDAModule::CUDA().cuArrayDestroy(Cached.LinearArray);
+				}
+				// Destroy external memory resources (tiled array from Vulkan)
+				if (Cached.MipArray)
+				{
+					FCUDAModule::CUDA().cuMipmappedArrayDestroy(Cached.MipArray);
+				}
+				if (Cached.ExternalMemory)
+				{
+					FCUDAModule::CUDA().cuDestroyExternalMemory(Cached.ExternalMemory);
+				}
+			}
+		}
+
+		FCUDAModule::CUDA().cuCtxPopCurrent(nullptr);
+	}
+
+	CUDATextureCache.Empty();
+#endif
+}
+
+bool FHardwareEncoderWrapper::SetCUDATextureFromVulkan(FRHITexture* Texture,
+	TSharedPtr<AVEncoder::FVideoEncoderInputFrame> InputFrame,
+	FString& OutErrorMessage)
+{
+#if PLATFORM_LINUX
+	if (!Texture || !InputFrame.IsValid())
+	{
+		OutErrorMessage = TEXT("Invalid texture or input frame");
+		return false;
+	}
+
+	if (!CudaContext)
+	{
+		OutErrorMessage = TEXT("CUDA context not initialized");
+		return false;
+	}
+
+	const int32 TexWidth = Texture->GetSizeX();
+	const int32 TexHeight = Texture->GetSizeY();
+
+	// Validate the layout this path actually depends on, before touching CUDA.
+	// The import below hardcodes a single-mip, non-MSAA, 4-channel 8-bit 2D layout
+	// (arrayDesc.NumChannels=4, CU_AD_FORMAT_UNSIGNED_INT8, numLevels=1, Depth=0) and a row
+	// pitch of TexWidth*4. A mismatch would not fail loudly: cuMemcpy2D would copy the wrong
+	// number of bytes per row and emit a silently corrupted frame instead of an error.
+	// Note: FRHITextureDesc::IsTexture2D() also accepts Texture2DArray, which this path cannot
+	// handle, so the dimension is compared directly.
+	const FRHITextureDesc& TextureDesc = Texture->GetDesc();
+	if (TextureDesc.Dimension != ETextureDimension::Texture2D
+		|| TextureDesc.Format != PF_B8G8R8A8
+		|| TextureDesc.NumMips != 1
+		|| TextureDesc.NumSamples != 1)
+	{
+		OutErrorMessage = FString::Printf(
+			TEXT("Unsupported texture for CUDA interop: %dx%d dimension=%d format=%s mips=%d samples=%d arraysize=%d (expected Texture2D / %s / 1 mip / no MSAA)"),
+			TexWidth, TexHeight,
+			(int32)TextureDesc.Dimension,
+			GPixelFormats[TextureDesc.Format].Name,
+			(int32)TextureDesc.NumMips,
+			(int32)TextureDesc.NumSamples,
+			(int32)TextureDesc.ArraySize,
+			GPixelFormats[PF_B8G8R8A8].Name);
+
+		// EncodeFrame runs per frame and its caller already logs OutErrorMessage on every
+		// failure, so emit the detailed diagnostic only once to avoid flooding the log.
+		if (!bLoggedUnsupportedTexture)
+		{
+			bLoggedUnsupportedTexture = true;
+			UE_LOG(LogTemp, Error, TEXT("HardwareEncoderWrapper: %s"), *OutErrorMessage);
+			UE_LOG(LogTemp, Error, TEXT("HardwareEncoderWrapper:   The CUDA/Vulkan zero-copy path requires the exact layout produced by FramePool (Create2D + PF_B8G8R8A8 + 1 mip + no MSAA)."));
+			UE_LOG(LogTemp, Error, TEXT("HardwareEncoderWrapper:   Every frame using this texture will fail to encode. Repeat occurrences of this diagnostic are suppressed."));
+		}
+		return false;
+	}
+
+	FCUDAModule::CUDA().cuCtxPushCurrent(CudaContext);
+
+	// Check cache first - if we have both TiledArray and LinearArray, just copy and return
+	{
+		FScopeLock Lock(&CUDACacheMutex);
+		FCachedCUDATexture* Cached = CUDATextureCache.Find(Texture);
+		if (Cached && Cached->bValid && Cached->TiledArray && Cached->LinearArray)
+		{
+			// CRITICAL FIX: Copy from tiled (Vulkan) array to linear (NVENC-compatible) array
+			// This de-tiles the Vulkan optimal-tiled memory into linear layout
+			CUDA_MEMCPY2D CopyParams = {};
+			CopyParams.srcMemoryType = CU_MEMORYTYPE_ARRAY;
+			CopyParams.srcArray = Cached->TiledArray;
+			CopyParams.dstMemoryType = CU_MEMORYTYPE_ARRAY;
+			CopyParams.dstArray = Cached->LinearArray;
+			CopyParams.WidthInBytes = Cached->Width * 4;  // 4 bytes per pixel (BGRA)
+			CopyParams.Height = Cached->Height;
+
+			CUresult CuRes = FCUDAModule::CUDA().cuMemcpy2D(&CopyParams);
+			FCUDAModule::CUDA().cuCtxPopCurrent(nullptr);
+
+			if (CuRes != CUDA_SUCCESS)
+			{
+				OutErrorMessage = FString::Printf(TEXT("cuMemcpy2D (cached) failed (%d)"), (int32)CuRes);
+				return false;
+			}
+
+			// Pass the LINEAR array to encoder (NOT the tiled one!)
+			InputFrame->SetTexture(Cached->LinearArray, AVEncoder::FVideoEncoderInputFrame::EUnderlyingRHI::Vulkan, nullptr,
+				[](CUarray) { /* No-op: Cache owns the resources */ });
+			return true;
+		}
+	}
+
+	// Not cached - need to import Vulkan texture AND create linear staging array
+	IVulkanDynamicRHI* VulkanRHI = GetIVulkanDynamicRHI();
+	if (!VulkanRHI)
+	{
+		FCUDAModule::CUDA().cuCtxPopCurrent(nullptr);
+		OutErrorMessage = TEXT("Failed to get Vulkan RHI interface");
+		return false;
+	}
+
+	const FVulkanRHIAllocationInfo AllocationInfo = VulkanRHI->RHIGetAllocationInfo(Texture);
+	VkDevice Device = VulkanRHI->RHIGetVkDevice();
+
+	PFN_vkGetMemoryFdKHR GetMemoryFdKHR = (PFN_vkGetMemoryFdKHR)VulkanRHI->RHIGetVkDeviceProcAddr("vkGetMemoryFdKHR");
+	if (!GetMemoryFdKHR)
+	{
+		FCUDAModule::CUDA().cuCtxPopCurrent(nullptr);
+		OutErrorMessage = TEXT("vkGetMemoryFdKHR not available");
+		return false;
+	}
+
+	int Fd = -1;
+	VkMemoryGetFdInfoKHR MemoryGetFdInfoKHR{};
+	MemoryGetFdInfoKHR.sType = VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR;
+	MemoryGetFdInfoKHR.memory = AllocationInfo.Handle;
+	MemoryGetFdInfoKHR.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR;
+	MemoryGetFdInfoKHR.pNext = nullptr;
+
+	VkResult VkRes = GetMemoryFdKHR(Device, &MemoryGetFdInfoKHR, &Fd);
+	if (VkRes != VK_SUCCESS || Fd < 0)
+	{
+		FCUDAModule::CUDA().cuCtxPopCurrent(nullptr);
+		OutErrorMessage = FString::Printf(TEXT("vkGetMemoryFdKHR failed (%d)"), (int32)VkRes);
+		return false;
+	}
+
+	// === STEP 1: Import Vulkan texture as TILED CUarray (external memory) ===
+	CUexternalMemory ExternalMemory = nullptr;
+	CUmipmappedArray MipArray = nullptr;
+	CUarray TiledArray = nullptr;
+
+	CUDA_EXTERNAL_MEMORY_HANDLE_DESC ExtDesc{};
+	ExtDesc.type = CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD;
+	ExtDesc.handle.fd = Fd;
+	ExtDesc.size = AllocationInfo.Offset + AllocationInfo.Size;
+
+	CUresult CuRes = FCUDAModule::CUDA().cuImportExternalMemory(&ExternalMemory, &ExtDesc);
+	if (CuRes != CUDA_SUCCESS)
+	{
+		FCUDAModule::CUDA().cuCtxPopCurrent(nullptr);
+		close(Fd);
+		OutErrorMessage = FString::Printf(TEXT("cuImportExternalMemory failed (%d)"), (int32)CuRes);
+		return false;
+	}
+	// FD ownership transfers to CUDA - don't close it
+
+	CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC MipDesc{};
+	MipDesc.numLevels = 1;
+	MipDesc.offset = AllocationInfo.Offset;
+	MipDesc.arrayDesc.Width = TexWidth;
+	MipDesc.arrayDesc.Height = TexHeight;
+	MipDesc.arrayDesc.Depth = 0;
+	MipDesc.arrayDesc.NumChannels = 4;
+	MipDesc.arrayDesc.Format = CU_AD_FORMAT_UNSIGNED_INT8;
+	MipDesc.arrayDesc.Flags = CUDA_ARRAY3D_SURFACE_LDST | CUDA_ARRAY3D_COLOR_ATTACHMENT;
+
+	CuRes = FCUDAModule::CUDA().cuExternalMemoryGetMappedMipmappedArray(&MipArray, ExternalMemory, &MipDesc);
+	if (CuRes != CUDA_SUCCESS)
+	{
+		FCUDAModule::CUDA().cuDestroyExternalMemory(ExternalMemory);
+		FCUDAModule::CUDA().cuCtxPopCurrent(nullptr);
+		OutErrorMessage = FString::Printf(TEXT("cuExternalMemoryGetMappedMipmappedArray failed (%d)"), (int32)CuRes);
+		return false;
+	}
+
+	CuRes = FCUDAModule::CUDA().cuMipmappedArrayGetLevel(&TiledArray, MipArray, 0);
+	if (CuRes != CUDA_SUCCESS)
+	{
+		FCUDAModule::CUDA().cuMipmappedArrayDestroy(MipArray);
+		FCUDAModule::CUDA().cuDestroyExternalMemory(ExternalMemory);
+		FCUDAModule::CUDA().cuCtxPopCurrent(nullptr);
+		OutErrorMessage = FString::Printf(TEXT("cuMipmappedArrayGetLevel failed (%d)"), (int32)CuRes);
+		return false;
+	}
+
+	// === STEP 2: Create LINEAR staging CUarray (NOT from external memory) ===
+	// This array uses standard CUDA memory layout which NVENC can read correctly
+	CUarray LinearArray = nullptr;
+	CUDA_ARRAY_DESCRIPTOR LinearArrayDesc = {};
+	LinearArrayDesc.Width = TexWidth;
+	LinearArrayDesc.Height = TexHeight;
+	LinearArrayDesc.Format = CU_AD_FORMAT_UNSIGNED_INT8;
+	LinearArrayDesc.NumChannels = 4;
+
+	CuRes = FCUDAModule::CUDA().cuArrayCreate(&LinearArray, &LinearArrayDesc);
+	if (CuRes != CUDA_SUCCESS)
+	{
+		FCUDAModule::CUDA().cuMipmappedArrayDestroy(MipArray);
+		FCUDAModule::CUDA().cuDestroyExternalMemory(ExternalMemory);
+		FCUDAModule::CUDA().cuCtxPopCurrent(nullptr);
+		OutErrorMessage = FString::Printf(TEXT("cuArrayCreate (linear staging) failed (%d)"), (int32)CuRes);
+		return false;
+	}
+
+	// === STEP 3: Copy from tiled to linear (de-tiles the data) ===
+	CUDA_MEMCPY2D CopyParams = {};
+	CopyParams.srcMemoryType = CU_MEMORYTYPE_ARRAY;
+	CopyParams.srcArray = TiledArray;
+	CopyParams.dstMemoryType = CU_MEMORYTYPE_ARRAY;
+	CopyParams.dstArray = LinearArray;
+	CopyParams.WidthInBytes = TexWidth * 4;  // 4 bytes per pixel (BGRA)
+	CopyParams.Height = TexHeight;
+
+	CuRes = FCUDAModule::CUDA().cuMemcpy2D(&CopyParams);
+	if (CuRes != CUDA_SUCCESS)
+	{
+		FCUDAModule::CUDA().cuArrayDestroy(LinearArray);
+		FCUDAModule::CUDA().cuMipmappedArrayDestroy(MipArray);
+		FCUDAModule::CUDA().cuDestroyExternalMemory(ExternalMemory);
+		FCUDAModule::CUDA().cuCtxPopCurrent(nullptr);
+		OutErrorMessage = FString::Printf(TEXT("cuMemcpy2D (initial) failed (%d)"), (int32)CuRes);
+		return false;
+	}
+
+	FCUDAModule::CUDA().cuCtxPopCurrent(nullptr);
+
+	// Cache both the tiled (external) and linear (staging) arrays
+	{
+		FScopeLock Lock(&CUDACacheMutex);
+		FCachedCUDATexture& Cached = CUDATextureCache.Add(Texture);
+		Cached.ExternalMemory = ExternalMemory;
+		Cached.MipArray = MipArray;
+		Cached.TiledArray = TiledArray;
+		Cached.LinearArray = LinearArray;
+		Cached.Width = TexWidth;
+		Cached.Height = TexHeight;
+		Cached.bValid = true;
+	}
+
+	UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Created CUDA linear staging array %dx%d format=%s (Total cached: %d)"),
+		TexWidth, TexHeight, GPixelFormats[TextureDesc.Format].Name, CUDATextureCache.Num());
+
+	// Pass the LINEAR array to encoder (NOT the tiled one!)
+	InputFrame->SetTexture(LinearArray, AVEncoder::FVideoEncoderInputFrame::EUnderlyingRHI::Vulkan, nullptr,
+		[](CUarray) { /* No-op: Cache owns the resources, will be cleaned up in ClearCUDATextureCache() */ });
+
+	return true;
+#else
+	OutErrorMessage = TEXT("CUDA interop only supported on Linux");
+	return false;
+#endif
+}
+
+//----------------------------------------------------------
+// Encoding Operations
+//----------------------------------------------------------
+
+bool FHardwareEncoderWrapper::EncodeFrame(FRHITexture* Texture, uint64 FrameNumber, bool bForceKeyframe)
+{
+	if (!bInitialized || bShuttingDown || !VideoEncoder.IsValid() || !VideoEncoderInput.IsValid())
+	{
+		EncodingFailureCount++;
+		return false;
+	}
+
+	if (!Texture || !Texture->IsValid())
+	{
+		UE_LOG(LogTemp, Warning, TEXT("HardwareEncoderWrapper: Invalid texture"));
+		EncodingFailureCount++;
+		return false;
+	}
+
+	// Get RHI type once (used for D3D12 workaround and texture setting)
+	const ERHIInterfaceType RHIType = RHIGetInterfaceType();
+
+	// WINDOWS D3D12 WORKAROUND:
+	// UE5.1 has a bug where pooled input frames don't clear D3D12.Texture on reuse,
+	// causing check(D3D12.Texture == nullptr) assertion failure at VideoEncoderInput.cpp:879.
+	// Workaround: Flush the input pool before obtaining a frame to force creation of new frames.
+	// This is less efficient but necessary for correctness on Windows D3D12 + NVENC.
+#if PLATFORM_WINDOWS
+	if (RHIType == ERHIInterfaceType::D3D12)
+	{
+		// Flush to discard any pooled frames that have stale D3D12.Texture pointers
+		VideoEncoderInput->Flush();
+	}
+#endif
+
+	// Obtain input frame from VideoEncoderInput
+	TSharedPtr<AVEncoder::FVideoEncoderInputFrame> InputFrame = VideoEncoderInput->ObtainInputFrame();
+	if (!InputFrame.IsValid())
+	{
+		UE_LOG(LogTemp, Warning, TEXT("HardwareEncoderWrapper: Failed to obtain input frame"));
+		EncodingFailureCount++;
+		return false;
+	}
+
+	// Return frame to encoder input on failure paths before Encode()
+	auto ReleaseInputFrame = [&InputFrame]()
+	{
+		if (InputFrame.IsValid())
+		{
+			InputFrame->Release();
+			InputFrame.Reset();
+		}
+	};
+
+	// Set frame dimensions
+	InputFrame->SetWidth(Config.Width);
+	InputFrame->SetHeight(Config.Height);
+
+	// Set timestamp and frame ID
+	InputFrame->SetTimestampUs(FPlatformTime::Seconds() * 1000000.0);
+	InputFrame->SetFrameID(FrameNumber);
+
+	// Set texture based on RHI type and encoding mode
+	// Note: RHIType already declared above for D3D12 workaround
+	bool bTextureSet = false;
+#if PLATFORM_WINDOWS
+	if (RHIType == ERHIInterfaceType::D3D11)
+	{
+		ID3D11Texture2D* D3D11Texture = static_cast<ID3D11Texture2D*>(Texture->GetNativeResource());
+		InputFrame->SetTexture(D3D11Texture, [](ID3D11Texture2D*){ /* Texture release callback */ });
+		bTextureSet = true;
+	}
+	else if (RHIType == ERHIInterfaceType::D3D12)
+	{
+		ID3D12Resource* D3D12Resource = static_cast<ID3D12Resource*>(Texture->GetNativeResource());
+		InputFrame->SetTexture(D3D12Resource, [](ID3D12Resource*){ /* Texture release callback */ });
+		bTextureSet = true;
+	}
+	else if (RHIType == ERHIInterfaceType::Vulkan)
+	{
+		// Windows Vulkan texture handling
+		VkImage VulkanImage = static_cast<VkImage>(Texture->GetNativeResource());
+		InputFrame->SetTexture(VulkanImage, [](VkImage){ /* Texture release callback */ });
+		bTextureSet = true;
+	}
+#elif PLATFORM_LINUX
+	if (RHIType == ERHIInterfaceType::Vulkan)
+	{
+		if (bUseCUDAMode)
+		{
+			FString InteropError;
+			if (!SetCUDATextureFromVulkan(Texture, InputFrame, InteropError))
+			{
+				UE_LOG(LogTemp, Error, TEXT("HardwareEncoderWrapper: CUDA/Vulkan interop failed: %s"), *InteropError);
+				EncodingFailureCount++;
+				ReleaseInputFrame();
+				return false;
+			}
+			bTextureSet = true;
+		}
+		else
+		{
+			// AMF mode: Direct Vulkan path
+			VkImage VulkanImage = static_cast<VkImage>(Texture->GetNativeResource());
+			InputFrame->SetTexture(VulkanImage, [](VkImage){ /* Texture release callback */ });
+			bTextureSet = true;
+		}
+	}
+#endif
+
+	if (!bTextureSet)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("HardwareEncoderWrapper: Unsupported RHI for SetTexture: %d"), (int32)RHIType);
+		EncodingFailureCount++;
+		ReleaseInputFrame();
+		return false;
+	}
+
+	// Prepare encode options
+	AVEncoder::FVideoEncoder::FEncodeOptions EncodeOptions;
+	EncodeOptions.bForceKeyFrame = bForceKeyframe || bForceNextKeyframe.exchange(false);
+
+	// CRITICAL: Final shutdown check right before Encode()
+	// Shutdown may have started between the initial check and here
+	if (bShuttingDown.load() || !VideoEncoder.IsValid())
+	{
+		ReleaseInputFrame();
+		return false;
+	}
+
+	// Submit frame to encoder
+	VideoEncoder->Encode(InputFrame, EncodeOptions);
+
+	CurrentFrameNumber = FrameNumber;
+	LastEncodeTime = FPlatformTime::Seconds();
+	TotalFramesEncoded++;
+
+	return true;
+}
+
+bool FHardwareEncoderWrapper::GetEncodedData(TArray<FEncodedNALUnit>& OutNALUnits)
+{
+	FScopeLock Lock(&NALQueueMutex);
+
+	OutNALUnits.Empty();
+
+	// Drain all available NAL units from queue
+	FEncodedNALUnit NALUnit;
+	while (NALOutputQueue.Dequeue(NALUnit))
+	{
+		// CRITICAL: Validate NAL data integrity after dequeue
+		// Detects memory corruption from encoder callback issues
+		const uint8* DataPtr = NALUnit.Data.GetData();
+		const int32 DataSize = NALUnit.Data.Num();
+
+		if (DataSize > 0 && (DataPtr == nullptr || reinterpret_cast<uintptr_t>(DataPtr) == ~static_cast<uintptr_t>(0)))
+		{
+			UE_LOG(LogTemp, Error, TEXT("HardwareEncoderWrapper: Corrupted NAL from queue (Ptr=0x%p, Size=%d) - encoder callback may have produced invalid data"),
+				DataPtr, DataSize);
+			continue; // Skip corrupted NAL
+		}
+
+		OutNALUnits.Add(MoveTemp(NALUnit));
+	}
+
+	return OutNALUnits.Num() > 0;
+}
+
+void FHardwareEncoderWrapper::ForceKeyframe()
+{
+	bForceNextKeyframe = true;
+	UE_LOG(LogTemp, Log, TEXT("HardwareEncoderWrapper: Next frame will be keyframe"));
+}
+
+//----------------------------------------------------------
+// Encoder Callbacks
+//----------------------------------------------------------
+
+void FHardwareEncoderWrapper::OnEncodedFrame(uint32 LayerIndex, const TSharedPtr<AVEncoder::FVideoEncoderInputFrame> Frame, const AVEncoder::FCodecPacket& Packet)
+{
+	// CRITICAL: Check shutdown flag first - encoder may call this callback during shutdown
+	if (bShuttingDown.load())
+	{
+		return;
+	}
+
+	if (!Frame.IsValid())
+	{
+		return;
+	}
+
+	// Check if we have data
+	if (Packet.DataSize == 0 || !Packet.Data.IsValid())
+	{
+		return;
+	}
+
+	// CRITICAL: Validate actual data pointer before use
+	// During shutdown, the pointer may be invalid (0xFFFFFFFFFFFFFFFF)
+	const uint8* PacketDataPtr = Packet.Data.Get();
+	if (PacketDataPtr == nullptr || reinterpret_cast<uintptr_t>(PacketDataPtr) == ~static_cast<uintptr_t>(0))
+	{
+		UE_LOG(LogTemp, Warning, TEXT("HardwareEncoderWrapper: Invalid packet data pointer (0x%p) - skipping"), PacketDataPtr);
+		return;
+	}
+
+	// Double-check shutdown flag after validation (may have changed)
+	if (bShuttingDown.load())
+	{
+		return;
+	}
+
+	// Update statistics
+	TotalBytesOutput += Packet.DataSize;
+	if (Packet.IsKeyFrame)
+	{
+		TotalKeyframesEncoded++;
+	}
+
+	// Parse bitstream into NAL units
+	TArray<FEncodedNALUnit> NALUnits;
+	ParseNALUnits(PacketDataPtr, Packet.DataSize, NALUnits);
+
+	// Check shutdown again after parsing (may have started during parse)
+	if (bShuttingDown.load())
+	{
+		return;
+	}
+
+	// Enqueue NAL units for retrieval
+	FScopeLock Lock(&NALQueueMutex);
+	for (FEncodedNALUnit& NALUnit : NALUnits)
+	{
+		// CRITICAL: Validate NAL data before enqueue
+		// If corrupted here, the problem is in ParseNALUnits or encoder output
+		const uint8* DataPtr = NALUnit.Data.GetData();
+		const int32 DataSize = NALUnit.Data.Num();
+
+		if (DataSize > 0 && (DataPtr == nullptr || reinterpret_cast<uintptr_t>(DataPtr) == ~static_cast<uintptr_t>(0)))
+		{
+			UE_LOG(LogTemp, Error, TEXT("HardwareEncoderWrapper: ParseNALUnits produced corrupted NAL (Ptr=0x%p, Size=%d) - encoder output may be invalid"),
+				DataPtr, DataSize);
+			continue;
+		}
+
+		NALUnit.TimestampMs = Frame->GetTimestampUs() / 1000;
+		NALUnit.FrameNumber = CurrentFrameNumber;
+		NALUnit.bIsKeyframe = Packet.IsKeyFrame;
+
+		NALOutputQueue.Enqueue(MoveTemp(NALUnit));
+	}
+
+	// Release the input frame
+	Frame->Release();
+}
+
+//----------------------------------------------------------
+// NAL Unit Processing
+//----------------------------------------------------------
+
+void FHardwareEncoderWrapper::ParseNALUnits(const uint8* BitstreamData, uint32 BitstreamSize, TArray<FEncodedNALUnit>& OutNALUnits)
+{
+	OutNALUnits.Empty();
+
+	// H.264 NAL units are separated by start codes: 0x00 0x00 0x00 0x01 (4 bytes)
+	// or 0x00 0x00 0x01 (3 bytes)
+
+	uint32 Index = 0;
+
+	while (Index < BitstreamSize - 4)
+	{
+		// Find start code
+		bool bFoundStartCode = false;
+		uint32 StartCodeSize = 0;
+
+		// Check for 4-byte start code (0x00 0x00 0x00 0x01)
+		if (BitstreamData[Index] == 0x00 && BitstreamData[Index + 1] == 0x00 &&
+			BitstreamData[Index + 2] == 0x00 && BitstreamData[Index + 3] == 0x01)
+		{
+			bFoundStartCode = true;
+			StartCodeSize = 4;
+		}
+		// Check for 3-byte start code (0x00 0x00 0x01)
+		else if (BitstreamData[Index] == 0x00 && BitstreamData[Index + 1] == 0x00 &&
+				 BitstreamData[Index + 2] == 0x01)
+		{
+			bFoundStartCode = true;
+			StartCodeSize = 3;
+		}
+
+		if (!bFoundStartCode)
+		{
+			Index++;
+			continue;
+		}
+
+		// Find next start code to determine NAL unit size
+		uint32 NextStartCode = Index + StartCodeSize;
+		while (NextStartCode < BitstreamSize - 4)
+		{
+			if ((BitstreamData[NextStartCode] == 0x00 && BitstreamData[NextStartCode + 1] == 0x00 &&
+				 BitstreamData[NextStartCode + 2] == 0x00 && BitstreamData[NextStartCode + 3] == 0x01) ||
+				(BitstreamData[NextStartCode] == 0x00 && BitstreamData[NextStartCode + 1] == 0x00 &&
+				 BitstreamData[NextStartCode + 2] == 0x01))
+			{
+				break; // Found next start code
+			}
+			NextStartCode++;
+		}
+
+		// If we didn't find another start code, this is the last NAL unit
+		if (NextStartCode >= BitstreamSize - 4)
+		{
+			NextStartCode = BitstreamSize;
+		}
+
+		// Extract NAL unit
+		const uint32 NALSize = NextStartCode - Index;
+		if (NALSize > StartCodeSize)
+		{
+			FEncodedNALUnit NALUnit;
+			NALUnit.Data.Append(&BitstreamData[Index], NALSize);
+			NALUnit.NALType = ExtractNALType(&BitstreamData[Index + StartCodeSize], NALSize - StartCodeSize);
+
+			OutNALUnits.Add(MoveTemp(NALUnit));
+		}
+
+		Index = NextStartCode;
+	}
+}
+
+uint8 FHardwareEncoderWrapper::ExtractNALType(const uint8* Data, uint32 Size) const
+{
+	if (!Data || Size < 1)
+	{
+		return 0;
+	}
+
+	// NAL unit type is in lower 5 bits of first byte
+	// Byte format: forbidden_zero_bit(1) + nal_ref_idc(2) + nal_unit_type(5)
+	return Data[0] & 0x1F;
+}
+
+//----------------------------------------------------------
+// Statistics
+//----------------------------------------------------------
+
+FString FHardwareEncoderWrapper::GetStatsString() const
+{
+	const double CurrentTime = FPlatformTime::Seconds();
+	const double TimeSinceLastEncode = CurrentTime - LastEncodeTime;
+
+	return FString::Printf(
+		TEXT("HardwareEncoder (%s): Encoded=%llu frames (%llu keyframes), Output=%.2f MB, Failures=%llu, LastEncode=%.3fs ago"),
+		*EncoderTypeToString(EncoderType),
+		TotalFramesEncoded.load(),
+		TotalKeyframesEncoded.load(),
+		TotalBytesOutput.load() / (1024.0 * 1024.0),
+		EncodingFailureCount.load(),
+		TimeSinceLastEncode
+	);
+}

--- a/Source/RealGazeboStreaming/Private/Encoder/HardwareEncoderWrapperLegacy.cpp
+++ b/Source/RealGazeboStreaming/Private/Encoder/HardwareEncoderWrapperLegacy.cpp
@@ -1,0 +1,9 @@
+// Copyright (c) 2024-2025 SUV Lab, Chungbuk National University
+// Licensed under the GNU General Public License v3.0.
+
+#if !PLATFORM_MAC
+// Keep the current upstream Windows/Linux implementation isolated in its own
+// translation unit so the macOS AVCodecs backend does not compile legacy
+// AVEncoder/CUDA includes on Apple platforms.
+#include "HardwareEncoderWrapper.upstream.inc"
+#endif

--- a/Source/RealGazeboStreaming/Private/Encoder/HardwareEncoderWrapperMac.cpp
+++ b/Source/RealGazeboStreaming/Private/Encoder/HardwareEncoderWrapperMac.cpp
@@ -1,1 +1,0 @@
-// macOS VideoToolbox backend will be added here.

--- a/Source/RealGazeboStreaming/Private/Encoder/HardwareEncoderWrapperMac.cpp
+++ b/Source/RealGazeboStreaming/Private/Encoder/HardwareEncoderWrapperMac.cpp
@@ -1,0 +1,1 @@
+// macOS VideoToolbox backend will be added here.

--- a/Source/RealGazeboStreaming/Public/Encoder/EncoderConfig.h
+++ b/Source/RealGazeboStreaming/Public/Encoder/EncoderConfig.h
@@ -9,177 +9,93 @@
 #include "CoreMinimal.h"
 #include "StreamingTypes.h"
 
-// UE 5.1: Must include full header to access nested enums
-// (FVideoEncoder::H264Profile, RateControlMode, MultipassMode)
+#if !PLATFORM_MAC
 #include "VideoEncoder.h"
+#endif
 
-/**
- * FEncoderConfig
- *
- * Converts RealGazebo streaming configuration to AVEncoder API parameters.
- * Enforces zero-copy GPU encoding with hardware-only acceleration.
- *
- * Key Features:
- * - Automatic bitrate calculation based on resolution/FPS
- * - UltraLowLatency preset mapping
- * - Baseline H.264 profile enforcement
- * - CBR (Constant Bitrate) rate control
- * - GOP size optimization for low latency
- */
 struct FEncoderConfig
 {
-	//----------------------------------------------------------
-	// Video Parameters
-	//----------------------------------------------------------
-
-	/** Target resolution width */
 	int32 Width = 1024;
-
-	/** Target resolution height */
 	int32 Height = 768;
-
-	/** Target frame rate */
 	int32 FrameRate = 30;
-
-	/** Target bitrate in bits per second (auto-calculated from resolution + FPS) */
-	uint64 Bitrate = 2000000; // 2 Mbps default
-
-	/** GOP (Group of Pictures) size - keyframe interval */
+	uint64 Bitrate = 2000000;
 	int32 GOPSize = 15;
 
-	//----------------------------------------------------------
-	// Encoder Settings (Hardcoded for Ultra-Low-Latency)
-	//----------------------------------------------------------
-
-	/** Encoder preset (always UltraLowLatency) */
 	EEncoderPreset Preset = EEncoderPreset::UltraLowLatency;
-
-	/** H.264 profile (always Baseline for maximum compatibility) */
 	ERealGazeboH264Profile Profile = ERealGazeboH264Profile::Baseline;
-
-	/** Rate control mode (always CBR for consistent latency) */
 	bool bConstantBitrate = true;
-
-	/** Zero-copy GPU encoding (always enabled) */
 	bool bZeroCopy = true;
-
-	/** Multipass encoding (disabled for low latency) */
 	bool bMultipass = false;
-
-	/** Number of B-frames (0 for ultra-low latency) */
 	int32 NumBFrames = 0;
-
-	/** Number of reference frames (1 for ultra-low latency) */
 	int32 NumRefFrames = 1;
 
-	//----------------------------------------------------------
-	// Construction & Conversion
-	//----------------------------------------------------------
-
-	/** Default constructor */
 	FEncoderConfig() = default;
 
-	/** Construct from FStreamConfig with auto-bitrate calculation */
 	explicit FEncoderConfig(const FStreamConfig& StreamConfig)
 	{
-		// Get resolution dimensions
 		StreamConfig.GetResolution(Width, Height);
-
-		// Get frame rate
 		FrameRate = StreamConfig.GetFrameRateValue();
-
-		// Calculate optimal bitrate (convert kbps to bps)
 		Bitrate = static_cast<uint64>(StreamConfig.GetBitrate()) * 1000;
-
-		// Set GOP size (auto-calculated as FPS/2)
 		GOPSize = StreamConfig.GetGOPSize();
-
-		// Encoder settings (always hardcoded for ultra-low latency)
 		Preset = StreamConfig.Preset;
 		Profile = StreamConfig.Profile;
 		bZeroCopy = StreamConfig.bZeroCopy;
 	}
 
-	//----------------------------------------------------------
-	// AVEncoder API Mapping (UE 5.1)
-	//----------------------------------------------------------
-
-	/** Convert to AVEncoder H.264 profile (UE 5.1: FVideoEncoder::H264Profile) */
+#if !PLATFORM_MAC
 	AVEncoder::FVideoEncoder::H264Profile GetAVEncoderProfile() const;
-
-	/** Convert to AVEncoder rate control mode (UE 5.1: FVideoEncoder::RateControlMode) */
 	AVEncoder::FVideoEncoder::RateControlMode GetRateControlMode() const;
-
-	/** Convert to AVEncoder multipass mode (UE 5.1: FVideoEncoder::MultipassMode) */
 	AVEncoder::FVideoEncoder::MultipassMode GetMultipassMode() const;
+#endif
 
-	//----------------------------------------------------------
-	// Validation
-	//----------------------------------------------------------
-
-	/** Validate configuration is suitable for ultra-low latency */
 	bool Validate(FString& OutErrorMessage) const
 	{
-		// Check resolution bounds
 		if (Width < 320 || Width > 3840)
 		{
 			OutErrorMessage = FString::Printf(TEXT("Invalid width %d (must be 320-3840)"), Width);
 			return false;
 		}
-
 		if (Height < 240 || Height > 2160)
 		{
 			OutErrorMessage = FString::Printf(TEXT("Invalid height %d (must be 240-2160)"), Height);
 			return false;
 		}
-
-		// Check frame rate
 		if (FrameRate < 10 || FrameRate > 120)
 		{
 			OutErrorMessage = FString::Printf(TEXT("Invalid frame rate %d (must be 10-120)"), FrameRate);
 			return false;
 		}
-
-		// Check bitrate
-		const uint64 MinBitrate = 500000; // 500 kbps
-		const uint64 MaxBitrate = 50000000; // 50 Mbps
+		const uint64 MinBitrate = 500000;
+		const uint64 MaxBitrate = 50000000;
 		if (Bitrate < MinBitrate || Bitrate > MaxBitrate)
 		{
 			OutErrorMessage = FString::Printf(TEXT("Invalid bitrate %llu (must be 500kbps-50Mbps)"), Bitrate);
 			return false;
 		}
-
-		// Check GOP size
 		if (GOPSize < 5 || GOPSize > 120)
 		{
 			OutErrorMessage = FString::Printf(TEXT("Invalid GOP size %d (must be 5-120)"), GOPSize);
 			return false;
 		}
-
-		// Validate ultra-low latency requirements
 		if (!bZeroCopy)
 		{
 			OutErrorMessage = TEXT("Zero-copy must be enabled for ultra-low latency");
 			return false;
 		}
-
 		if (NumBFrames != 0)
 		{
 			OutErrorMessage = TEXT("B-frames must be disabled (0) for ultra-low latency");
 			return false;
 		}
-
 		if (NumRefFrames > 1)
 		{
 			OutErrorMessage = TEXT("Reference frames must be 1 for ultra-low latency");
 			return false;
 		}
-
 		OutErrorMessage = TEXT("Validation successful");
 		return true;
 	}
 
-	/** Get configuration summary for logging */
 	FString ToString() const
 	{
 		return FString::Printf(

--- a/Source/RealGazeboStreaming/Public/Encoder/EncoderConfig.h
+++ b/Source/RealGazeboStreaming/Public/Encoder/EncoderConfig.h
@@ -9,93 +9,181 @@
 #include "CoreMinimal.h"
 #include "StreamingTypes.h"
 
+// UE 5.1: Must include full header to access nested enums
+// (FVideoEncoder::H264Profile, RateControlMode, MultipassMode)
 #if !PLATFORM_MAC
 #include "VideoEncoder.h"
 #endif
 
+/**
+ * FEncoderConfig
+ *
+ * Converts RealGazebo streaming configuration to AVEncoder API parameters.
+ * Enforces zero-copy GPU encoding with hardware-only acceleration.
+ *
+ * Key Features:
+ * - Automatic bitrate calculation based on resolution/FPS
+ * - UltraLowLatency preset mapping
+ * - Baseline H.264 profile enforcement
+ * - CBR (Constant Bitrate) rate control
+ * - GOP size optimization for low latency
+ */
 struct FEncoderConfig
 {
+	//----------------------------------------------------------
+	// Video Parameters
+	//----------------------------------------------------------
+
+	/** Target resolution width */
 	int32 Width = 1024;
+
+	/** Target resolution height */
 	int32 Height = 768;
+
+	/** Target frame rate */
 	int32 FrameRate = 30;
-	uint64 Bitrate = 2000000;
+
+	/** Target bitrate in bits per second (auto-calculated from resolution + FPS) */
+	uint64 Bitrate = 2000000; // 2 Mbps default
+
+	/** GOP (Group of Pictures) size - keyframe interval */
 	int32 GOPSize = 15;
 
+	//----------------------------------------------------------
+	// Encoder Settings (Hardcoded for Ultra-Low-Latency)
+	//----------------------------------------------------------
+
+	/** Encoder preset (always UltraLowLatency) */
 	EEncoderPreset Preset = EEncoderPreset::UltraLowLatency;
+
+	/** H.264 profile (always Baseline for maximum compatibility) */
 	ERealGazeboH264Profile Profile = ERealGazeboH264Profile::Baseline;
+
+	/** Rate control mode (always CBR for consistent latency) */
 	bool bConstantBitrate = true;
+
+	/** Zero-copy GPU encoding (always enabled) */
 	bool bZeroCopy = true;
+
+	/** Multipass encoding (disabled for low latency) */
 	bool bMultipass = false;
+
+	/** Number of B-frames (0 for ultra-low latency) */
 	int32 NumBFrames = 0;
+
+	/** Number of reference frames (1 for ultra-low latency) */
 	int32 NumRefFrames = 1;
 
+	//----------------------------------------------------------
+	// Construction & Conversion
+	//----------------------------------------------------------
+
+	/** Default constructor */
 	FEncoderConfig() = default;
 
+	/** Construct from FStreamConfig with auto-bitrate calculation */
 	explicit FEncoderConfig(const FStreamConfig& StreamConfig)
 	{
+		// Get resolution dimensions
 		StreamConfig.GetResolution(Width, Height);
+
+		// Get frame rate
 		FrameRate = StreamConfig.GetFrameRateValue();
+
+		// Calculate optimal bitrate (convert kbps to bps)
 		Bitrate = static_cast<uint64>(StreamConfig.GetBitrate()) * 1000;
+
+		// Set GOP size (auto-calculated as FPS/2)
 		GOPSize = StreamConfig.GetGOPSize();
+
+		// Encoder settings (always hardcoded for ultra-low latency)
 		Preset = StreamConfig.Preset;
 		Profile = StreamConfig.Profile;
 		bZeroCopy = StreamConfig.bZeroCopy;
 	}
 
+	//----------------------------------------------------------
+	// AVEncoder API Mapping (UE 5.1; unavailable on macOS)
+	//----------------------------------------------------------
+
 #if !PLATFORM_MAC
+	/** Convert to AVEncoder H.264 profile (UE 5.1: FVideoEncoder::H264Profile) */
 	AVEncoder::FVideoEncoder::H264Profile GetAVEncoderProfile() const;
+
+	/** Convert to AVEncoder rate control mode (UE 5.1: FVideoEncoder::RateControlMode) */
 	AVEncoder::FVideoEncoder::RateControlMode GetRateControlMode() const;
+
+	/** Convert to AVEncoder multipass mode (UE 5.1: FVideoEncoder::MultipassMode) */
 	AVEncoder::FVideoEncoder::MultipassMode GetMultipassMode() const;
 #endif
 
+	//----------------------------------------------------------
+	// Validation
+	//----------------------------------------------------------
+
+	/** Validate configuration is suitable for ultra-low latency */
 	bool Validate(FString& OutErrorMessage) const
 	{
+		// Check resolution bounds
 		if (Width < 320 || Width > 3840)
 		{
 			OutErrorMessage = FString::Printf(TEXT("Invalid width %d (must be 320-3840)"), Width);
 			return false;
 		}
+
 		if (Height < 240 || Height > 2160)
 		{
 			OutErrorMessage = FString::Printf(TEXT("Invalid height %d (must be 240-2160)"), Height);
 			return false;
 		}
+
+		// Check frame rate
 		if (FrameRate < 10 || FrameRate > 120)
 		{
 			OutErrorMessage = FString::Printf(TEXT("Invalid frame rate %d (must be 10-120)"), FrameRate);
 			return false;
 		}
-		const uint64 MinBitrate = 500000;
-		const uint64 MaxBitrate = 50000000;
+
+		// Check bitrate
+		const uint64 MinBitrate = 500000; // 500 kbps
+		const uint64 MaxBitrate = 50000000; // 50 Mbps
 		if (Bitrate < MinBitrate || Bitrate > MaxBitrate)
 		{
 			OutErrorMessage = FString::Printf(TEXT("Invalid bitrate %llu (must be 500kbps-50Mbps)"), Bitrate);
 			return false;
 		}
+
+		// Check GOP size
 		if (GOPSize < 5 || GOPSize > 120)
 		{
 			OutErrorMessage = FString::Printf(TEXT("Invalid GOP size %d (must be 5-120)"), GOPSize);
 			return false;
 		}
+
+		// Validate ultra-low latency requirements
 		if (!bZeroCopy)
 		{
 			OutErrorMessage = TEXT("Zero-copy must be enabled for ultra-low latency");
 			return false;
 		}
+
 		if (NumBFrames != 0)
 		{
 			OutErrorMessage = TEXT("B-frames must be disabled (0) for ultra-low latency");
 			return false;
 		}
+
 		if (NumRefFrames > 1)
 		{
 			OutErrorMessage = TEXT("Reference frames must be 1 for ultra-low latency");
 			return false;
 		}
+
 		OutErrorMessage = TEXT("Validation successful");
 		return true;
 	}
 
+	/** Get configuration summary for logging */
 	FString ToString() const
 	{
 		return FString::Printf(

--- a/Source/RealGazeboStreaming/Public/Encoder/HardwareEncoderWrapper.h
+++ b/Source/RealGazeboStreaming/Public/Encoder/HardwareEncoderWrapper.h
@@ -1,9 +1,5 @@
 // Copyright (c) 2024-2025 SUV Lab, Chungbuk National University
-// Author    : Gonapinuwala Lahiru Sandaruwan
-// Supervisor: Prof. SungTae Moon - Project lead & research supervision
 // Licensed under the GNU General Public License v3.0.
-// See LICENSE file in the project root for full license information.
-
 #pragma once
 
 #include "CoreMinimal.h"
@@ -11,327 +7,118 @@
 #include "EncoderConfig.h"
 #include "RHI.h"
 
-// Forward declare CUDA types to avoid heavyweight includes in the header
-struct CUctx_st;
-using CUcontext = CUctx_st*;
-struct CUarray_st;
-using CUarray = CUarray_st*;
-struct CUmipmappedArray_st;
-using CUmipmappedArray = CUmipmappedArray_st*;
-struct CUextMemory_st;
-using CUexternalMemory = CUextMemory_st*;
+#if PLATFORM_MAC
+class USimpleVideoEncoder;
+#endif
 
-/**
- * FCachedCUDATexture
- *
- * Cached CUDA resources for a single pooled texture (NVIDIA GPUs on Linux only).
- * Textures are imported once and reused for all frames to minimize overhead.
- *
- * CRITICAL VULKAN TILING FIX:
- * Vulkan uses VK_IMAGE_TILING_OPTIMAL which stores pixels in a GPU-optimized swizzled pattern
- * for fast rendering. When imported into CUDA via external memory, this tiling is preserved
- * but NVENC cannot read swizzled data - it requires linear memory layout.
- *
- * Solution: Two-stage approach:
- * 1. Import Vulkan texture to TiledArray (preserves swizzled layout)
- * 2. Create LinearArray with linear memory layout
- * 3. Use cuMemcpy2D to copy from TiledArray -> LinearArray
- * 4. Feed LinearArray to NVENC for encoding
- *
- * This ensures NVENC receives correctly formatted linear memory it can process.
- */
+#if PLATFORM_LINUX
+struct CUctx_st; using CUcontext = CUctx_st*;
+struct CUarray_st; using CUarray = CUarray_st*;
+struct CUmipmappedArray_st; using CUmipmappedArray = CUmipmappedArray_st*;
+struct CUextMemory_st; using CUexternalMemory = CUextMemory_st*;
+
 struct FCachedCUDATexture
 {
-	//----------------------------------------------------------
-	// External Memory Resources (Tiled Layout from Vulkan)
-	//----------------------------------------------------------
-	CUexternalMemory ExternalMemory = nullptr;  // Vulkan->CUDA memory handle
-	CUmipmappedArray MipArray = nullptr;         // Mipmap array wrapper
-	CUarray TiledArray = nullptr;                // Swizzled/tiled array from Vulkan
-
-	//----------------------------------------------------------
-	// Linear Staging Array (Created via cuArrayCreate)
-	//----------------------------------------------------------
-	CUarray LinearArray = nullptr;  // Linear array for NVENC input (correct layout)
-
-	//----------------------------------------------------------
-	// Metadata
-	//----------------------------------------------------------
-	bool bValid = false;   // Is this cache entry valid?
-	int32 Width = 0;       // Texture width in pixels
-	int32 Height = 0;      // Texture height in pixels
+	CUexternalMemory ExternalMemory = nullptr;
+	CUmipmappedArray MipArray = nullptr;
+	CUarray TiledArray = nullptr;
+	CUarray LinearArray = nullptr;
+	bool bValid = false;
+	int32 Width = 0;
+	int32 Height = 0;
 };
+#endif
 
-// Forward declarations
+#if !PLATFORM_MAC
 namespace AVEncoder
 {
 	class FVideoEncoder;
 	class FVideoEncoderInput;
 	class FVideoEncoderInputFrame;
-	class FCodecPacket;  // UE 5.1 defines this as class, not struct
+	class FCodecPacket;
 	enum class EVideoFrameFormat;
 }
+#endif
 
-/**
- * FEncodedNALUnit
- *
- * Represents a single encoded NAL (Network Abstraction Layer) unit ready for RTSP streaming.
- * NAL units are the atomic packets of H.264 video, containing either video frames or codec metadata.
- *
- * NAL Unit Types:
- * - Type 1-4: P-frames and B-frames (predictive/bi-directional frames)
- * - Type 5: IDR frames (keyframes, complete independent frames)
- * - Type 7: SPS (Sequence Parameter Set) - codec initialization data
- * - Type 8: PPS (Picture Parameter Set) - frame-level codec parameters
- */
 struct FEncodedNALUnit
 {
-	/** H.264 bitstream data with Annex-B start code (0x00000001) prefix */
 	TArray<uint8> Data;
-
-	/** NAL unit type extracted from H.264 header (1-5=frames, 7=SPS, 8=PPS) */
 	uint8 NALType = 0;
-
-	/** Is this a keyframe (IDR frame)? Keyframes can be decoded independently */
 	bool bIsKeyframe = false;
-
-	/** Presentation timestamp in milliseconds - when this frame should be displayed */
 	uint64 TimestampMs = 0;
-
-	/** Sequential frame number since stream started */
 	uint64 FrameNumber = 0;
-
-	/** Get NAL unit size in bytes including start code */
 	int32 GetSize() const { return Data.Num(); }
-
-	/** Is this NAL unit valid and ready for streaming? */
 	bool IsValid() const { return Data.Num() > 0; }
-
-	/** Is this a Sequence Parameter Set (codec initialization)? */
 	bool IsSPS() const { return NALType == 7; }
-
-	/** Is this a Picture Parameter Set (frame-level parameters)? */
 	bool IsPPS() const { return NALType == 8; }
-
-	/** Is this a video slice (actual encoded frame data)? */
 	bool IsSlice() const { return NALType >= 1 && NALType <= 5; }
 };
 
-/**
- * FHardwareEncoderWrapper
- *
- * Per-stream hardware video encoder wrapper using GPU acceleration.
- * Wraps Unreal Engine's AVEncoder API to provide NVENC (NVIDIA) or AMF (AMD) encoding.
- *
- * CRITICAL ISOLATION REQUIREMENT:
- * Each stream MUST have its own dedicated encoder instance. Never share encoders between
- * streams as this causes encoder state pollution, leading to corrupted frames and crosstalk.
- *
- * Supported Hardware:
- * - NVENC: NVIDIA GPUs (GTX 1000+ series, all RTX cards)
- *   - Windows: Direct3D 11/12 texture input
- *   - Linux: CUDA texture input via Vulkan->CUDA interop
- * - AMF: AMD GPUs (RX 400+ series, all Radeon 5000/6000/7000)
- *   - Windows: Direct3D 11/12 texture input
- *   - Linux: Vulkan texture input
- *
- * Features:
- * - Automatic GPU detection and encoder selection
- * - Zero-copy GPU pipeline (texture never leaves GPU memory)
- * - H.264 Baseline profile (maximum client compatibility)
- * - Ultra-low latency preset (<16ms encoding time per frame)
- * - Outputs NAL units ready for RTSP/RTP streaming
- *
- * Encoding Pipeline:
- * 1. Initialize() - Detect GPU, create encoder, configure parameters
- * 2. EncodeFrame() - Submit GPU texture to hardware encoder
- * 3. GetEncodedData() - Retrieve encoded NAL units from output queue
- * 4. Shutdown() - Stop encoder and release all GPU resources
- */
 class FHardwareEncoderWrapper
 {
 public:
-	//----------------------------------------------------------
-	// Construction & Initialization
-	//----------------------------------------------------------
-
-	/** Constructor */
 	FHardwareEncoderWrapper();
-
-	/** Destructor */
 	~FHardwareEncoderWrapper();
-
-	/**
-	 * Initialize hardware encoder with configuration.
-	 *
-	 * @param Config - Encoder configuration
-	 * @param OutErrorMessage - Error message if failed
-	 * @return True if initialized successfully
-	 */
 	bool Initialize(const FEncoderConfig& Config, FString& OutErrorMessage);
-
-	/** Shutdown encoder and release resources */
 	void Shutdown();
-
-	/** Signal encoder to stop accepting new frames (call before thread shutdown) */
 	void PrepareForShutdown() { bShuttingDown.store(true); }
-
-	//----------------------------------------------------------
-	// Encoding Operations
-	//----------------------------------------------------------
-
-	/**
-	 * Encode a frame from GPU texture.
-	 * This is the zero-copy path - texture stays on GPU.
-	 *
-	 * @param Texture - GPU texture to encode (from frame pool)
-	 * @param FrameNumber - Frame sequence number
-	 * @param bForceKeyframe - Force this frame to be a keyframe
-	 * @return True if frame submitted successfully
-	 */
 	bool EncodeFrame(FRHITexture* Texture, uint64 FrameNumber, bool bForceKeyframe = false);
-
-	/**
-	 * Retrieve encoded NAL units.
-	 * Call this after EncodeFrame() to get output data.
-	 *
-	 * @param OutNALUnits - Output NAL units
-	 * @return True if data retrieved successfully
-	 */
 	bool GetEncodedData(TArray<FEncodedNALUnit>& OutNALUnits);
-
-	/** Force next frame to be a keyframe (IDR) */
 	void ForceKeyframe();
-
-	//----------------------------------------------------------
-	// Status & Information
-	//----------------------------------------------------------
-
-	/** Is encoder initialized and ready? */
 	bool IsReady() const { return bInitialized; }
-
-	/** Get detected encoder type */
 	EEncoderType GetEncoderType() const { return EncoderType; }
-
-	/** Get encoder configuration */
 	const FEncoderConfig& GetConfig() const { return Config; }
-
-	/** Get encoding statistics string */
 	FString GetStatsString() const;
 
 private:
-	//----------------------------------------------------------
-	// Internal Initialization
-	//----------------------------------------------------------
-
-	/** Detect and create appropriate hardware encoder */
 	bool CreateHardwareEncoder(FString& OutErrorMessage);
-
-	/** Register encoder callbacks */
 	void RegisterEncoderCallbacks();
 
-	/** Map a Vulkan texture to a CUarray for NVENC (Linux, NVIDIA) */
+#if PLATFORM_LINUX
 	bool SetCUDATextureFromVulkan(FRHITexture* Texture,
 		TSharedPtr<AVEncoder::FVideoEncoderInputFrame> InputFrame,
 		FString& OutErrorMessage);
+	void ClearCUDATextureCache();
+#endif
 
-	//----------------------------------------------------------
-	// Encoder Callbacks
-	//----------------------------------------------------------
+#if !PLATFORM_MAC
+	void OnEncodedFrame(uint32 LayerIndex,
+		const TSharedPtr<AVEncoder::FVideoEncoderInputFrame> Frame,
+		const AVEncoder::FCodecPacket& Packet);
+#endif
 
-	/** Called when encoder outputs data (UE 5.1 callback signature) */
-	void OnEncodedFrame(uint32 LayerIndex, const TSharedPtr<AVEncoder::FVideoEncoderInputFrame> Frame, const AVEncoder::FCodecPacket& Packet);
-
-	//----------------------------------------------------------
-	// NAL Unit Processing
-	//----------------------------------------------------------
-
-	/** Parse encoded bitstream into NAL units */
 	void ParseNALUnits(const uint8* BitstreamData, uint32 BitstreamSize, TArray<FEncodedNALUnit>& OutNALUnits);
-
-	/** Extract NAL unit type from H.264 header */
 	uint8 ExtractNALType(const uint8* Data, uint32 Size) const;
 
-	//----------------------------------------------------------
-	// Configuration
-	//----------------------------------------------------------
-
-	/** Encoder configuration */
 	FEncoderConfig Config;
-
-	/** Detected encoder type */
 	EEncoderType EncoderType = EEncoderType::Unknown;
 
-	/** Cached CUDA context when using NVENC on Linux */
+#if PLATFORM_LINUX
 	CUcontext CudaContext = nullptr;
-
-	/** Cache of CUDA imports per texture (import once, reuse) */
 	TMap<FRHITexture*, FCachedCUDATexture> CUDATextureCache;
-
-	/** Mutex for CUDA cache access */
 	FCriticalSection CUDACacheMutex;
-
-	/** Suppress repeat logging of an unsupported input texture (validated every frame) */
-	bool bLoggedUnsupportedTexture = false;
-
-	/** Clear the CUDA texture cache (called on shutdown) */
-	void ClearCUDATextureCache();
-
-	//----------------------------------------------------------
-	// AVEncoder Instances (PER-STREAM - NOT SHARED!)
-	//----------------------------------------------------------
-
-	/** AVEncoder video encoder input (provides frames to encoder) */
-	TSharedPtr<AVEncoder::FVideoEncoderInput> VideoEncoderInput;
-
-	/** AVEncoder video encoder instance (UNIQUE per stream!) */
-	TUniquePtr<AVEncoder::FVideoEncoder> VideoEncoder;
-
-	//----------------------------------------------------------
-	// State
-	//----------------------------------------------------------
-
-	/** Is encoder initialized? */
-	std::atomic<bool> bInitialized{false};
-
-	/** Is encoder shutting down? */
-	std::atomic<bool> bShuttingDown{false};
-
-	/** Force next frame to be keyframe? */
-	std::atomic<bool> bForceNextKeyframe{false};
-
-	/** Current frame number */
-	std::atomic<uint64> CurrentFrameNumber{0};
-
-	/** Using CUDA mode for encoding? (NVENC on Linux) */
 	bool bUseCUDAMode = false;
+	bool bLoggedUnsupportedTexture = false;
+#endif
 
-	//----------------------------------------------------------
-	// Output Queue (PER-STREAM - NOT SHARED!)
-	//----------------------------------------------------------
+#if !PLATFORM_MAC
+	TSharedPtr<AVEncoder::FVideoEncoderInput> VideoEncoderInput;
+	TUniquePtr<AVEncoder::FVideoEncoder> VideoEncoder;
+#endif
 
-	/** Queue of encoded NAL units (PER-INSTANCE - not static!) */
+#if PLATFORM_MAC
+	USimpleVideoEncoder* AVCodecEncoder = nullptr;
+#endif
+
+	std::atomic<bool> bInitialized{false};
+	std::atomic<bool> bShuttingDown{false};
+	std::atomic<bool> bForceNextKeyframe{false};
+	std::atomic<uint64> CurrentFrameNumber{0};
 	TQueue<FEncodedNALUnit> NALOutputQueue;
-
-	/** Mutex for NAL queue access */
 	FCriticalSection NALQueueMutex;
-
-	//----------------------------------------------------------
-	// Statistics
-	//----------------------------------------------------------
-
-	/** Total frames encoded */
 	std::atomic<uint64> TotalFramesEncoded{0};
-
-	/** Total keyframes encoded */
 	std::atomic<uint64> TotalKeyframesEncoded{0};
-
-	/** Total bytes output */
 	std::atomic<uint64> TotalBytesOutput{0};
-
-	/** Encoding failures */
 	std::atomic<uint64> EncodingFailureCount{0};
-
-	/** Last encode timestamp */
 	double LastEncodeTime = 0.0;
 };

--- a/Source/RealGazeboStreaming/Public/Encoder/HardwareEncoderWrapper.h
+++ b/Source/RealGazeboStreaming/Public/Encoder/HardwareEncoderWrapper.h
@@ -74,11 +74,16 @@ private:
 	bool CreateHardwareEncoder(FString& OutErrorMessage);
 	void RegisterEncoderCallbacks();
 
+	// Declared on all non-Mac platforms because upstream Shutdown() calls it
+	// unconditionally; the implementation is a no-op outside Linux.
+#if !PLATFORM_MAC
+	void ClearCUDATextureCache();
+#endif
+
 #if PLATFORM_LINUX
 	bool SetCUDATextureFromVulkan(FRHITexture* Texture,
 		TSharedPtr<AVEncoder::FVideoEncoderInputFrame> InputFrame,
 		FString& OutErrorMessage);
-	void ClearCUDATextureCache();
 #endif
 
 #if !PLATFORM_MAC

--- a/Source/RealGazeboStreaming/Public/Transport/EncodedVideoSink.h
+++ b/Source/RealGazeboStreaming/Public/Transport/EncodedVideoSink.h
@@ -1,0 +1,88 @@
+// Copyright (c) 2024-2026 SUV Lab, Chungbuk National University
+// Licensed under the GNU General Public License v3.0.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Encoder/HardwareEncoderWrapper.h"
+
+/**
+ * Metadata associated with one encoded video access unit.
+ *
+ * This deliberately contains transport-neutral sensor/platform state so one
+ * encoder output can be fan-out to RTSP/WebRTC and STANAG 4609/MISB KLV
+ * without rendering or encoding the frame twice.
+ */
+struct REALGAZEBOSTREAMING_API FEncodedVideoMetadata
+{
+	/** Monotonic frame identifier assigned by the streaming pipeline. */
+	uint64 FrameNumber = 0;
+
+	/** Capture/encode timestamp in microseconds. */
+	uint64 TimestampUs = 0;
+
+	/** WGS-84 platform position, when known. */
+	double LatitudeDeg = 0.0;
+	double LongitudeDeg = 0.0;
+	double AltitudeMslMeters = 0.0;
+	bool bHasWGS84Position = false;
+
+	/** Platform attitude in degrees, when known. */
+	double PlatformRollDeg = 0.0;
+	double PlatformPitchDeg = 0.0;
+	double PlatformHeadingDeg = 0.0;
+	bool bHasPlatformAttitude = false;
+
+	/** Sensor/camera attitude relative to the platform in degrees, when known. */
+	double SensorRelativeRollDeg = 0.0;
+	double SensorRelativePitchDeg = 0.0;
+	double SensorRelativeYawDeg = 0.0;
+	bool bHasSensorAttitude = false;
+
+	/** Camera field of view, when known. */
+	double HorizontalFovDeg = 0.0;
+	double VerticalFovDeg = 0.0;
+	bool bHasFieldOfView = false;
+};
+
+/**
+ * Transport-neutral consumer of encoded H.264/H.265 access units.
+ *
+ * Implementations may packetize the same encoded stream for:
+ * - RTSP/RTP (legacy RealGazebo path)
+ * - browser transport (preferably WebRTC)
+ * - STANAG 4609 MPEG-TS with MISB KLV metadata
+ * - recording/debug sinks
+ *
+ * Sinks MUST NOT require a second video encode.
+ */
+class REALGAZEBOSTREAMING_API IEncodedVideoSink
+{
+public:
+	virtual ~IEncodedVideoSink() = default;
+
+	/** Called once when a stream becomes active. */
+	virtual bool Start(FString& OutErrorMessage) = 0;
+
+	/** Called during pipeline shutdown before encoder resources are released. */
+	virtual void Stop() = 0;
+
+	/**
+	 * Consume encoded NAL units for one frame/access unit.
+	 * Implementations must copy any data they retain asynchronously.
+	 */
+	virtual void PushEncodedVideo(
+		const TArray<FEncodedNALUnit>& NALUnits,
+		const FEncodedVideoMetadata& Metadata) = 0;
+
+	/**
+	 * Whether this sink currently wants frames.
+	 *
+	 * RTSP can return false when no client is connected. STANAG recorders or
+	 * continuous browser gateways can return true independently of RTSP state.
+	 */
+	virtual bool WantsFrames() const { return true; }
+
+	/** Human-readable sink name for logging/diagnostics. */
+	virtual FString GetName() const = 0;
+};

--- a/Source/RealGazeboStreaming/RealGazeboStreaming.Build.cs
+++ b/Source/RealGazeboStreaming/RealGazeboStreaming.Build.cs
@@ -12,9 +12,6 @@ public class RealGazeboStreaming : ModuleRules
     public RealGazeboStreaming(ReadOnlyTargetRules Target) : base(Target)
     {
         PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
-
-        // CRITICAL: Disable Unity builds to prevent BufferedPacket name collision
-        // between Live555 (MultiFramedRTPSource.hh) and Unreal (PacketHandler.h)
         bUseUnity = false;
 
         PublicIncludePaths.AddRange(new string[]
@@ -42,7 +39,6 @@ public class RealGazeboStreaming : ModuleRules
             "Engine",
             "RHI",
             "RenderCore",
-            "AVEncoder",
             "Live555",
             "RealGazeboBridge"
         });
@@ -51,9 +47,32 @@ public class RealGazeboStreaming : ModuleRules
         {
             "Slate",
             "SlateCore",
-            "DeveloperSettings",
-            "CUDA"
+            "DeveloperSettings"
         });
+
+        if (Target.Platform == UnrealTargetPlatform.Mac)
+        {
+            PrivateDependencyModuleNames.AddRange(new string[]
+            {
+                "AVCodecsCore",
+                "AVCodecsCoreRHI",
+                "VTCodecs",
+                "VTCodecsRHI"
+            });
+
+            PublicFrameworks.AddRange(new string[]
+            {
+                "AVFoundation",
+                "VideoToolbox",
+                "CoreMedia",
+                "CoreVideo"
+            });
+        }
+        else
+        {
+            PublicDependencyModuleNames.Add("AVEncoder");
+            PrivateDependencyModuleNames.Add("CUDA");
+        }
 
         if (Target.Platform == UnrealTargetPlatform.Win64 ||
             Target.Platform == UnrealTargetPlatform.Linux)
@@ -69,13 +88,7 @@ public class RealGazeboStreaming : ModuleRules
                 "D3D11RHI",
                 "D3D12RHI"
             });
-
             AddEngineThirdPartyPrivateStaticDependencies(Target, "DX11", "DX12");
-        }
-
-        if (Target.IsInPlatformGroup(UnrealPlatformGroup.Unix))
-        {
-            PrivateDependencyModuleNames.Add("VulkanRHI");
         }
 
         if (Target.bBuildEditor)

--- a/docs/CUAS_HEADLESS_VERTICAL_SLICE.md
+++ b/docs/CUAS_HEADLESS_VERTICAL_SLICE.md
@@ -1,0 +1,109 @@
+# Headless UE 5.8 C-UAS vertical slice
+
+## Goal
+
+Run Unreal Engine 5.8 without a visible window while keeping full GPU rendering active. Vehicle motion is authoritative outside Unreal (Gazebo + ArduPilot SITL + MAVLink/bridge). Unreal mirrors vehicle/camera transforms and renders FPV cameras into GPU textures. Encoded video is produced once and fanned out to browser and STANAG 4609-compatible transports.
+
+## Authority boundaries
+
+- Gazebo / ArduPilot: vehicle dynamics, autopilot, swarm trajectory execution.
+- RealGazeboBridge: transport authoritative pose/state into Unreal and manage vehicle lifecycle.
+- Unreal Engine 5.8: photorealistic scene and sensor rendering only.
+- RealGazeboStreaming: capture, GPU texture lifecycle, hardware encoding, encoded stream fan-out.
+- C-Track / Furia: tactical tracks, identity, sensor/video association and operator UI.
+
+## Initial trajectory source
+
+For the first end-to-end demo, vehicles may use deterministic/random Lissajous references plus Boids-style separation/alignment/cohesion and collision avoidance. Unreal must not independently simulate those dynamics.
+
+## Required video pipeline
+
+```text
+Gazebo + ArduPilot SITL
+        |
+      MAVLink / bridge pose
+        v
+Unreal actor + FPV SceneCaptureComponent2D
+        |
+        v
+GPU render target / FRHITexture
+        |
+        | no ReadPixels(), no PNG/JPEG, no CPU frame staging
+        v
+hardware encoder
+  macOS: Metal -> AVCodecs/VTCodecs -> VideoToolbox
+  Linux: Vulkan/CUDA -> NVENC/AMF
+  Windows: D3D/Vulkan -> NVENC/AMF
+        |
+        v
+single encoded H.264 access-unit stream
+        |
+        +--> browser transport (prefer WebRTC for low latency)
+        |
+        +--> STANAG 4609 packaging (MPEG-TS + MISB KLV)
+        |
+        +--> optional RTSP compatibility / recording
+```
+
+The encoder output MUST be shared by transports. Browser and STANAG paths must not trigger independent renders or independent video encodes.
+
+## Immediate architectural corrections
+
+### 1. Rendering must not depend on RTSP viewers
+
+Current `FStreamingPipeline::CaptureFrame()` skips capture when `FH264StreamSource` has no active RTSP client. That is valid as an RTSP optimization but invalid as the global render-demand policy: a STANAG recorder or WebRTC consumer may require frames while RTSP has no clients.
+
+Replace the RTSP-specific gate with aggregate sink demand:
+
+```text
+ShouldCapture = AnyEncodedVideoSink.WantsFrames()
+```
+
+A continuous recorder/STANAG sink returns true. An RTSP sink may return false while idle.
+
+### 2. Encoded video fan-out
+
+`FStreamingPipeline::OnNALUnitsEncoded()` should publish to a collection of `IEncodedVideoSink` instances. `FH264StreamSource` becomes an RTSP sink adapter instead of being the only destination.
+
+### 3. Metadata must travel beside encoded video
+
+Each encoded access unit should have transport-neutral metadata available before packetization:
+
+- monotonic frame number and timestamp
+- WGS-84 latitude/longitude/altitude MSL
+- platform roll/pitch/heading
+- sensor-relative attitude
+- horizontal/vertical FOV
+- later: slant range, target location, track ID, sensor ID, security/classification fields as required
+
+STANAG/MISB packetization maps this metadata to KLV. Browser transport can expose the same metadata over a synchronized data channel.
+
+### 4. Headless means no visible window, not null rendering
+
+Do not use Unreal modes that disable RHI/rendering. The process must keep Metal/Vulkan/D3D active and allow `SceneCaptureComponent2D::CaptureScene()` to render. Launch configuration must suppress the visible game/editor window while preserving GPU rendering.
+
+## Vertical slice acceptance test
+
+One vehicle is enough initially.
+
+1. Start Gazebo + ArduPilot SITL.
+2. Vehicle follows a scripted/Lissajous trajectory.
+3. Bridge receives authoritative pose and updates exactly one Unreal vehicle actor.
+4. FPV camera transform follows that actor.
+5. UE 5.8 runs without a visible window and renders the FPV `SceneCaptureComponent2D`.
+6. Frame remains GPU-resident through capture and hardware encode.
+7. Browser receives live low-latency video.
+8. The same encoded H.264 stream is packetized for a STANAG 4609-compatible output with synchronized metadata.
+9. No RTSP client is required to keep the STANAG/browser path rendering.
+
+## Scale-out after vertical slice
+
+Only after the one-drone path is measured and stable:
+
+- N vehicles/cameras
+- render scheduling and per-camera FPS budgets
+- encoder/session pooling limits
+- demand-driven capture per sink
+- C-Track track-to-video association
+- CAT-129 / CAT-015 / CAT-016 / CAT-062 integration upstream of C-Track as appropriate
+- end-to-end latency and GPU budget telemetry


### PR DESCRIPTION
## macOS Support for RealGazebo

Adds full macOS support to the RealGazebo plugin, targeting **UE5.8+** with Apple VideoToolbox hardware encoding via AVCodecs+VTCodecs.

### Changes

**Platform support:**
- Added `Mac` to all 4 module `PlatformAllowList` entries
- Guarded CUDA/NVENC/AMF code behind `PLATFORM_LINUX` / `PLATFORM_WINDOWS`
- AVEncoder module dependency is Linux/Windows only (not available on Mac)

**Live555 (arm64):**
- Built Live555 2025.09.17 for Mac arm64
- Links CoreFoundation + CoreServices frameworks
- kqueue-based networking optimizations

**Hardware encoding (Mac → VideoToolbox):**
- AVCodecsCore + VTCodecs plugin dependencies for Apple VideoToolbox
- `USimpleVideoEncoder::SendFrame(FTextureRHIRef)` — zero-copy Metal texture → H.264
- GPU readback + YUV420P software fallback when VideoToolbox unavailable
- New `EEncoderType::VideoToolbox` type

**Build automation:**
- `quick_build.sh`: one-command build (symlink → generate Xcode → UBT build)
- `build_mac.sh`: generic build for any UE5 project
- `demo_5_drones.sh`: full demo launching UE5 + spawning 5 drones on C-track
- `spawn_drones.py`: spawn drones via Python remote execution

**Fixes:**
- Renamed `EH264Profile` → `EGazeboH264Profile` (collision with AVCodecsCore)
- `FTexture2DRHIRef` → `FTextureRHIRef` (UE5.8 deprecation)
- `#ifdef REALGAZEBO_STREAMING_DEBUG` (UE5.8 -Werror fix)
- `StartAllCameraStreams` returns int32 for accurate status
- Platform-aware error messages for Mac users

### Build

```bash
cd RealGazebo && ./quick_build.sh
```

### Streaming on Mac

```
Metal Texture (FRHITexture*)
  → USimpleVideoEncoder::SendFrame(FTextureRHIRef)  [zero-copy GPU→GPU]
    → AVCodecsRHI → FVideoResourceRHI → FVideoResourceMetal
      → TVideoEncoderVT<FVideoResourceMetal>
        → VTCompressionSession (VideoToolbox HW)
          → H.264 NAL → Live555 RTSP
```

### Limitations

- Requires UE5.8+ for AVCodecsCore + VTCodecs (not available in UE5.7)
- No hardware encoding on Mac without VTCodecs plugin (falls back to software YUV420P)