### PR TITLE
feat: add UE-spawned vehicle registration and Blueprint vehicle switching support

### DIFF
--- a/Source/RealGazebo/Private/Core/RealGazeboManager.cpp
+++ b/Source/RealGazebo/Private/Core/RealGazeboManager.cpp
@@ -18,7 +18,9 @@
 #include "Components/Widget.h"
 #include "Blueprint/UserWidget.h"
 #include "Data/RealGazeboVehicleData.h"
+#include "Data/RealGazeboVehicleListItem.h"
 #include "Data/VehicleTypeImageData.h"
+#include "Vehicles/VehicleBasePawn.h"
 
 ARealGazeboManager::ARealGazeboManager()
 {
@@ -39,6 +41,7 @@ ARealGazeboManager::ARealGazeboManager()
     UISubsystem = nullptr;
     StreamingSubsystem = nullptr;
     ViewerDirector = nullptr;
+    InputSelectedVehicleItem = nullptr;
 
     // Initialize runtime DataTables
     RuntimeBridgeDataTable = nullptr;
@@ -360,6 +363,7 @@ void ARealGazeboManager::InitializeCameraUI()
     );
 
     ViewerDirector = UISubsystem->GetViewerDirector();
+    BindViewerDirectorEvents();
 
     // Configure camera presets on the viewer director
     if (ViewerDirector.IsValid() && CameraPresets.Num() > 0)
@@ -382,18 +386,64 @@ void ARealGazeboManager::InitializeCameraUI()
 
 void ARealGazeboManager::CleanupCameraUI()
 {
+    UnbindViewerDirectorEvents();
+
     if (UISubsystem.IsValid())
     {
         UISubsystem->CleanupCameraUI();
     }
 
     ViewerDirector = nullptr;
+    InputSelectedVehicleItem = nullptr;
     WidgetInViewportStatus = false;
     bDidStartUI = false;
     UIStatus = TEXT("Cleaned Up");
     OnUICleanedUp();
 
     UE_LOG(LogRealGazebo, Log, TEXT("Camera UI cleaned up"));
+}
+
+void ARealGazeboManager::BindViewerDirectorEvents()
+{
+    if (!ViewerDirector.IsValid())
+    {
+        return;
+    }
+
+    ViewerDirector->OnVehicleChangedByInput().RemoveAll(this);
+    ViewerDirector->OnVehicleChangedByInput().AddUObject(
+        this,
+        &ARealGazeboManager::HandleVehicleChangedByInput);
+}
+
+void ARealGazeboManager::UnbindViewerDirectorEvents()
+{
+    if (ViewerDirector.IsValid())
+    {
+        ViewerDirector->OnVehicleChangedByInput().RemoveAll(this);
+    }
+}
+
+void ARealGazeboManager::HandleVehicleChangedByInput(AVehicleBasePawn* Vehicle)
+{
+    InputSelectedVehicleItem = nullptr;
+
+    if (IsValid(Vehicle))
+    {
+        URealGazeboVehicleListItem* VehicleItem = NewObject<URealGazeboVehicleListItem>(this);
+        VehicleItem->VehicleID = Vehicle->VehicleID;
+        VehicleItem->VehicleTypeName = Vehicle->VehicleTypeName.IsEmpty()
+            ? FString::Printf(TEXT("Type_%d"), Vehicle->VehicleType)
+            : Vehicle->VehicleTypeName;
+        VehicleItem->VehicleName = FString::Printf(
+            TEXT("%s_%d"),
+            *VehicleItem->VehicleTypeName,
+            Vehicle->VehicleID.VehicleNum);
+        VehicleItem->UpdateFromRuntimeData(Vehicle->GetCurrentRuntimeData());
+        InputSelectedVehicleItem = VehicleItem;
+    }
+
+    OnVehicleChangedByInput.Broadcast(InputSelectedVehicleItem);
 }
 
 void ARealGazeboManager::SetMouseCursorAlwaysVisible(bool bVisible)

--- a/Source/RealGazebo/Public/Core/RealGazeboManager.h
+++ b/Source/RealGazebo/Public/Core/RealGazeboManager.h
@@ -18,7 +18,14 @@
 class UGazeboBridgeSubsystem;
 class URealGazeboUISubsystem;
 class URealGazeboStreamingSubsystem;
+class URealGazeboVehicleListItem;
 class ARealGazeboViewerDirector;
+class AVehicleBasePawn;
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
+    FRealGazeboVehicleListItemChangedByInput,
+    URealGazeboVehicleListItem*,
+    VehicleItem);
 
 /**
  * Unified RealGazebo Manager Actor
@@ -359,6 +366,10 @@ public:
     UPROPERTY(BlueprintAssignable, Category = "RealGazebo|Bridge Events")
     FOnVehicleDataReceived OnVehicleSpawned;
 
+    /** Called when comma/period input changes the viewer vehicle */
+    UPROPERTY(BlueprintAssignable, Category = "RealGazebo|Camera Events")
+    FRealGazeboVehicleListItemChangedByInput OnVehicleChangedByInput;
+
     //----------------------------------------------------------
     // Events - UI Lifecycle (Blueprint Implementable)
     //----------------------------------------------------------
@@ -417,6 +428,10 @@ protected:
     UPROPERTY()
     TWeakObjectPtr<ARealGazeboViewerDirector> ViewerDirector;
 
+    /** Vehicle list item retained for the latest keyboard-selected vehicle */
+    UPROPERTY(Transient)
+    TObjectPtr<URealGazeboVehicleListItem> InputSelectedVehicleItem;
+
     //----------------------------------------------------------
     // Status Display (Visible for Debug)
     //----------------------------------------------------------
@@ -466,6 +481,15 @@ protected:
 
     /** Configure performance and debug settings */
     void ConfigurePerformanceAndDebugSettings();
+
+    /** Bind keyboard vehicle-change notifications from the viewer director */
+    void BindViewerDirectorEvents();
+
+    /** Unbind keyboard vehicle-change notifications from the viewer director */
+    void UnbindViewerDirectorEvents();
+
+    /** Convert a keyboard-selected vehicle Pawn to a Blueprint vehicle item */
+    void HandleVehicleChangedByInput(AVehicleBasePawn* Vehicle);
 
     /** Get the player controller for widget operations */
     APlayerController* GetPlayerController() const;

--- a/Source/RealGazeboBridge/Private/Core/GazeboBridgeSubsystem.cpp
+++ b/Source/RealGazeboBridge/Private/Core/GazeboBridgeSubsystem.cpp
@@ -269,9 +269,27 @@ bool UGazeboBridgeSubsystem::IsBridgeActive() const
 
 void UGazeboBridgeSubsystem::ClearAllVehicles()
 {
+    TArray<AVehicleBasePawn*> UntrackedVisualPawns;
+    for (const TPair<FVehicleID, FVehicleRuntimeData>& Pair : VehicleDataMap)
+    {
+        AVehicleBasePawn* VisualPawn = Pair.Value.VisualPawn.Get();
+        if (IsValid(VisualPawn) && (!VehiclePool || !VehiclePool->IsVehicleTracked(VisualPawn)))
+        {
+            UntrackedVisualPawns.AddUnique(VisualPawn);
+        }
+    }
+
     if (VehiclePool)
     {
         VehiclePool->ReleaseAllActiveVehicles();
+    }
+
+    for (AVehicleBasePawn* VisualPawn : UntrackedVisualPawns)
+    {
+        if (IsValid(VisualPawn))
+        {
+            VisualPawn->Destroy();
+        }
     }
 
     VehicleDataMap.Empty();
@@ -384,6 +402,82 @@ TArray<FVehicleID> UGazeboBridgeSubsystem::FindVehiclesByNum(uint8 VehicleNum) c
     }
 
     return FoundVehicles;
+}
+
+bool UGazeboBridgeSubsystem::RegisterVehiclePawn(const FVehicleID& VehicleID, AVehicleBasePawn* VehiclePawn)
+{
+    if (!IsValid(VehiclePawn))
+    {
+        UE_LOG(LogRealGazeboBridge, Warning,
+               TEXT("RegisterVehiclePawn failed: invalid pawn for vehicle %s"),
+               *VehicleID.ToString());
+        return false;
+    }
+
+    FVehicleRuntimeData& RuntimeData = VehicleDataMap.FindOrAdd(VehicleID);
+    if (RuntimeData.VisualPawn.IsValid() && RuntimeData.VisualPawn.Get() != VehiclePawn)
+    {
+        UE_LOG(LogRealGazeboBridge, Warning,
+               TEXT("RegisterVehiclePawn failed: vehicle %s already has a different visual pawn"),
+               *VehicleID.ToString());
+        return false;
+    }
+
+    RuntimeData.Position = VehiclePawn->GetActorLocation();
+    RuntimeData.Rotation = VehiclePawn->GetActorRotation().Quaternion();
+    RuntimeData.LastUpdateTime = GetWorld() ? GetWorld()->GetTimeSeconds() : 0.0f;
+    RuntimeData.VehicleType = VehicleID.VehicleType;
+    RuntimeData.VisualPawn = VehiclePawn;
+
+    VehiclePawn->InitializeForPool(VehicleID, VehicleID.VehicleType);
+
+    if (OnVehicleSpawned.IsBound())
+    {
+        FBridgePoseData PoseData;
+        PoseData.VehicleNum = VehicleID.VehicleNum;
+        PoseData.VehicleType = VehicleID.VehicleType;
+        PoseData.Position = RuntimeData.Position;
+        PoseData.Rotation = RuntimeData.Rotation.Rotator();
+
+        OnVehicleSpawned.Broadcast(PoseData);
+    }
+
+    UE_LOG(LogRealGazeboBridge, Display,
+           TEXT("Registered existing vehicle pawn: %s (%s)"),
+           *VehicleID.ToString(), *VehiclePawn->GetName());
+
+    return true;
+}
+
+bool UGazeboBridgeSubsystem::UnregisterVehiclePawn(const FVehicleID& VehicleID, bool bDestroyVisualPawn)
+{
+    FVehicleRuntimeData* RuntimeData = VehicleDataMap.Find(VehicleID);
+    if (!RuntimeData)
+    {
+        UE_LOG(LogRealGazeboBridge, Warning,
+               TEXT("UnregisterVehiclePawn failed: vehicle %s is not registered"),
+               *VehicleID.ToString());
+        return false;
+    }
+
+    AVehicleBasePawn* VisualPawn = RuntimeData->VisualPawn.Get();
+    if (bDestroyVisualPawn && IsValid(VisualPawn))
+    {
+        if (VehiclePool && VehiclePool->IsVehicleTracked(VisualPawn))
+        {
+            VehiclePool->DestroyVehicleActor(VisualPawn);
+        }
+
+        VisualPawn->Destroy();
+    }
+
+    VehicleDataMap.Remove(VehicleID);
+
+    UE_LOG(LogRealGazeboBridge, Display,
+           TEXT("Unregistered vehicle pawn: %s (DestroyVisualPawn=%s)"),
+           *VehicleID.ToString(), bDestroyVisualPawn ? TEXT("true") : TEXT("false"));
+
+    return true;
 }
 
 bool UGazeboBridgeSubsystem::GetVehicleConfig(uint8 VehicleType, FBridgeVehicleConfigRow& OutConfig) const
@@ -506,7 +600,7 @@ void UGazeboBridgeSubsystem::BatchUpdateVehicles()
 }
 
 void UGazeboBridgeSubsystem::GetPerformanceStats(int32& OutTotalVehicles, int32& OutVisibleVehicles, 
-                                               float& OutAverageUpdateTime, float& OutMemoryUsageMB) const
+                                                 float& OutAverageUpdateTime, float& OutMemoryUsageMB) const
 {
     OutTotalVehicles = GetTotalVehicleCount();
     OutVisibleVehicles = GetVisibleVehicleCount();

--- a/Source/RealGazeboBridge/Private/Core/RealGazeboBridgeBlueprintLibrary.cpp
+++ b/Source/RealGazeboBridge/Private/Core/RealGazeboBridgeBlueprintLibrary.cpp
@@ -1,0 +1,15 @@
+#include "Core/RealGazeboBridgeBlueprintLibrary.h"
+
+bool URealGazeboBridgeBlueprintLibrary::EqualEqual_VehicleIDVehicleID(
+    const FVehicleID& A,
+    const FVehicleID& B)
+{
+    return A == B;
+}
+
+bool URealGazeboBridgeBlueprintLibrary::NotEqual_VehicleIDVehicleID(
+    const FVehicleID& A,
+    const FVehicleID& B)
+{
+    return A != B;
+}

--- a/Source/RealGazeboBridge/Private/Vehicles/VehiclePoolManager.cpp
+++ b/Source/RealGazeboBridge/Private/Vehicles/VehiclePoolManager.cpp
@@ -294,6 +294,11 @@ void UVehiclePoolManager::DestroyVehicleActor(AVehicleBasePawn* Vehicle)
     UE_LOG(LogRealGazeboBridge, Verbose, TEXT("Vehicle actor removed from pool tracking (ready for destruction)"));
 }
 
+bool UVehiclePoolManager::IsVehicleTracked(const AVehicleBasePawn* Vehicle) const
+{
+    return IsValid(Vehicle) && PawnToTypeMap.Contains(const_cast<AVehicleBasePawn*>(Vehicle));
+}
+
 void UVehiclePoolManager::ReleaseAllActiveVehicles()
 {
     TArray<AVehicleBasePawn*> ActorsToRelease;

--- a/Source/RealGazeboBridge/Public/Core/GazeboBridgeSubsystem.h
+++ b/Source/RealGazeboBridge/Public/Core/GazeboBridgeSubsystem.h
@@ -146,6 +146,19 @@ public:
     UFUNCTION(BlueprintCallable, Category = "Bridge|Vehicles")
     TArray<FVehicleID> FindVehiclesByNum(uint8 VehicleNum) const;
 
+    /** Register an already-spawned Unreal pawn as this vehicle's visual pawn.
+     *  Use this before sending a UE-initiated spawn command to Gazebo so the
+     *  returned pose stream updates the existing pawn instead of auto-spawning
+     *  a duplicate visual pawn. */
+    UFUNCTION(BlueprintCallable, Category = "Bridge|Vehicles")
+    bool RegisterVehiclePawn(const FVehicleID& VehicleID, AVehicleBasePawn* VehiclePawn);
+
+    /** Remove a manually registered visual pawn from runtime tracking.
+     *  Use bDestroyVisualPawn=true when rolling back a local spawn after the
+     *  Gazebo spawn command failed. */
+    UFUNCTION(BlueprintCallable, Category = "Bridge|Vehicles")
+    bool UnregisterVehiclePawn(const FVehicleID& VehicleID, bool bDestroyVisualPawn = false);
+
     UFUNCTION(BlueprintCallable, Category = "Bridge|Configuration")
     bool GetVehicleConfig(uint8 VehicleType, FBridgeVehicleConfigRow& OutConfig) const;
 

--- a/Source/RealGazeboBridge/Public/Core/GazeboBridgeTypes.h
+++ b/Source/RealGazeboBridge/Public/Core/GazeboBridgeTypes.h
@@ -69,6 +69,15 @@ struct REALGAZEBOBRIDGE_API FVehicleID
     }
 };
 
+template<>
+struct TStructOpsTypeTraits<FVehicleID> : public TStructOpsTypeTraitsBase2<FVehicleID>
+{
+    enum
+    {
+        WithIdenticalViaEquality = true
+    };
+};
+
 //----------------------------------------------------------
 // Network Data Structures (maintain compatibility)
 //----------------------------------------------------------

--- a/Source/RealGazeboBridge/Public/Core/RealGazeboBridgeBlueprintLibrary.h
+++ b/Source/RealGazeboBridge/Public/Core/RealGazeboBridgeBlueprintLibrary.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Core/GazeboBridgeTypes.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "RealGazeboBridgeBlueprintLibrary.generated.h"
+
+/** Blueprint utilities for RealGazebo Bridge data types. */
+UCLASS()
+class REALGAZEBOBRIDGE_API URealGazeboBridgeBlueprintLibrary : public UBlueprintFunctionLibrary
+{
+    GENERATED_BODY()
+
+public:
+    /** Returns whether two vehicle IDs are equal. */
+    UFUNCTION(
+        BlueprintPure,
+        Category = "RealGazebo|Vehicle ID",
+        meta = (
+            DisplayName = "Equal (Vehicle ID)",
+            CompactNodeTitle = "==",
+            ScriptOperator = "==",
+            Keywords = "== equal",
+            BlueprintThreadSafe))
+    static bool EqualEqual_VehicleIDVehicleID(
+        const FVehicleID& A,
+        const FVehicleID& B);
+
+    /** Returns whether two vehicle IDs are different. */
+    UFUNCTION(
+        BlueprintPure,
+        Category = "RealGazebo|Vehicle ID",
+        meta = (
+            DisplayName = "Not Equal (Vehicle ID)",
+            CompactNodeTitle = "!=",
+            ScriptOperator = "!=",
+            Keywords = "!= not equal",
+            BlueprintThreadSafe))
+    static bool NotEqual_VehicleIDVehicleID(
+        const FVehicleID& A,
+        const FVehicleID& B);
+};

--- a/Source/RealGazeboBridge/Public/Vehicles/VehiclePoolManager.h
+++ b/Source/RealGazeboBridge/Public/Vehicles/VehiclePoolManager.h
@@ -64,6 +64,9 @@ public:
     /** Remove actor from pool tracking (used before destroying the actor completely) */
     void DestroyVehicleActor(AVehicleBasePawn* Vehicle);
 
+    /** Check whether the actor is managed by this pool. */
+    bool IsVehicleTracked(const AVehicleBasePawn* Vehicle) const;
+
     /** Force release all active actors */
     void ReleaseAllActiveVehicles();
 

--- a/Source/RealGazeboUI/Private/ViewerController/RealGazeboViewerDirector.cpp
+++ b/Source/RealGazeboUI/Private/ViewerController/RealGazeboViewerDirector.cpp
@@ -119,7 +119,7 @@ void ARealGazeboViewerDirector::InitializeForBeginPlay()
     // Discover vehicles
     DiscoverVehicles();
 
-    // Setup input bindings (only M/F/B keys needed now)
+    // Setup input bindings
     SetupInputBindings();
 
     // Don't start in manual mode - let user start with UE5's default pawn
@@ -137,7 +137,11 @@ void ARealGazeboViewerDirector::SetupInputBindings()
     URealGazeboBlueprintLib::BindActionToKey(TEXT("RealGazebo_FirstPersonCamera"), EKeys::F, this, &ARealGazeboViewerDirector::InputFirstPersonCamera);
     URealGazeboBlueprintLib::BindActionToKey(TEXT("RealGazebo_ThirdPersonCamera"), EKeys::B, this, &ARealGazeboViewerDirector::InputThirdPersonCamera);
 
-    // Bind camera preset keys (1, 2, 3)
+    // Bind vehicle switching keys
+    URealGazeboBlueprintLib::BindActionToKey(TEXT("RealGazebo_PreviousVehicle"), EKeys::Comma, this, &ARealGazeboViewerDirector::InputPreviousVehicle);
+    URealGazeboBlueprintLib::BindActionToKey(TEXT("RealGazebo_NextVehicle"), EKeys::Period, this, &ARealGazeboViewerDirector::InputNextVehicle);
+
+    // Bind camera preset keys (1-7)
     URealGazeboBlueprintLib::BindActionToKey(TEXT("RealGazebo_CameraPreset1"), EKeys::One, this, &ARealGazeboViewerDirector::InputPreset1);
     URealGazeboBlueprintLib::BindActionToKey(TEXT("RealGazebo_CameraPreset2"), EKeys::Two, this, &ARealGazeboViewerDirector::InputPreset2);
     URealGazeboBlueprintLib::BindActionToKey(TEXT("RealGazebo_CameraPreset3"), EKeys::Three, this, &ARealGazeboViewerDirector::InputPreset3);
@@ -165,6 +169,47 @@ void ARealGazeboViewerDirector::DiscoverVehicles()
     }
 
     UE_LOG(LogRealGazeboUI, Log, TEXT("ViewerDirector: Discovered %d vehicles"), AvailableVehicles.Num());
+}
+
+void ARealGazeboViewerDirector::CycleCurrentVehicle(int32 Direction)
+{
+    if (Direction == 0)
+    {
+        return;
+    }
+
+    APlayerController* PC = GetWorld() ? GetWorld()->GetFirstPlayerController() : nullptr;
+    AVehicleBasePawn* PossessedVehicle = PC ? Cast<AVehicleBasePawn>(PC->GetPawn()) : nullptr;
+    if (!IsValid(PossessedVehicle))
+    {
+        return;
+    }
+
+    int32 CurrentIndex = AvailableVehicles.IndexOfByKey(PossessedVehicle);
+    if (CurrentIndex == INDEX_NONE)
+    {
+        DiscoverVehicles();
+        CurrentIndex = AvailableVehicles.IndexOfByKey(PossessedVehicle);
+    }
+
+    const int32 VehicleCount = AvailableVehicles.Num();
+    if (CurrentIndex == INDEX_NONE || VehicleCount < 2)
+    {
+        return;
+    }
+
+    const int32 StepDirection = Direction > 0 ? 1 : -1;
+    for (int32 Step = 1; Step < VehicleCount; ++Step)
+    {
+        const int32 CandidateIndex = (CurrentIndex + StepDirection * Step + VehicleCount) % VehicleCount;
+        AVehicleBasePawn* CandidateVehicle = AvailableVehicles[CandidateIndex];
+        if (IsValid(CandidateVehicle) && CandidateVehicle != PossessedVehicle)
+        {
+            SetCurrentVehicle(CandidateVehicle);
+            VehicleChangedByInputDelegate.Broadcast(CandidateVehicle);
+            return;
+        }
+    }
 }
 
 void ARealGazeboViewerDirector::SetCameraMode(ERealGazeboViewerMode NewMode)
@@ -195,13 +240,23 @@ void ARealGazeboViewerDirector::SetCameraMode(ERealGazeboViewerMode NewMode)
 
 void ARealGazeboViewerDirector::SetCurrentVehicle(AVehicleBasePawn* Vehicle)
 {
-    if (CurrentVehicle == Vehicle)
+    const bool bVehicleChanged = CurrentVehicle != Vehicle;
+    if (!bVehicleChanged)
     {
-        return;
+        APlayerController* PC = GetWorld() ? GetWorld()->GetFirstPlayerController() : nullptr;
+        const bool bNeedsPossessionRestore = IsValid(Vehicle) && PC && PC->GetPawn() != Vehicle;
+        if (!bNeedsPossessionRestore)
+        {
+            return;
+        }
+
+        UE_LOG(LogRealGazeboUI, Log,
+               TEXT("ViewerDirector: Restoring possession and camera for current vehicle %s"),
+               *Vehicle->GetName());
     }
 
     // Disable cameras on previous vehicle if using component system
-    if (CurrentVehicle)
+    if (bVehicleChanged && CurrentVehicle)
     {
         URealGazeboCameraControllerComponent* PreviousCameraController = FindCameraControllerForVehicle(CurrentVehicle);
         if (PreviousCameraController)
@@ -210,7 +265,10 @@ void ARealGazeboViewerDirector::SetCurrentVehicle(AVehicleBasePawn* Vehicle)
         }
     }
 
-    CurrentVehicle = Vehicle;
+    if (bVehicleChanged)
+    {
+        CurrentVehicle = Vehicle;
+    }
 
     if (CurrentVehicle)
     {
@@ -550,6 +608,16 @@ void ARealGazeboViewerDirector::InputFirstPersonCamera()
 void ARealGazeboViewerDirector::InputThirdPersonCamera()
 {
     SetCameraMode(ERealGazeboViewerMode::ThirdPerson);
+}
+
+void ARealGazeboViewerDirector::InputPreviousVehicle()
+{
+    CycleCurrentVehicle(-1);
+}
+
+void ARealGazeboViewerDirector::InputNextVehicle()
+{
+    CycleCurrentVehicle(1);
 }
 
 void ARealGazeboViewerDirector::InputPreset1()

--- a/Source/RealGazeboUI/Private/Widgets/RealGazeboMainWidget.cpp
+++ b/Source/RealGazeboUI/Private/Widgets/RealGazeboMainWidget.cpp
@@ -127,11 +127,6 @@ void URealGazeboMainWidget::NativeDestruct()
 {
     // Destructing UI
 
-    if (ViewerDirector.IsValid())
-    {
-        ViewerDirector->OnVehicleChangedByInput().RemoveAll(this);
-    }
-    
     // Clear timer
     if (UWorld* World = GetWorld())
     {
@@ -612,38 +607,9 @@ void URealGazeboMainWidget::SetVehicleTypeImageDataTable(UDataTable* DataTable)
 
 void URealGazeboMainWidget::SetViewerDirector(ARealGazeboViewerDirector* InViewerDirector)
 {
-    if (ViewerDirector.IsValid())
-    {
-        ViewerDirector->OnVehicleChangedByInput().RemoveAll(this);
-    }
-
     ViewerDirector = InViewerDirector;
 
-    if (ViewerDirector.IsValid())
-    {
-        ViewerDirector->OnVehicleChangedByInput().AddUObject(
-            this,
-            &URealGazeboMainWidget::HandleVehicleChangedByInput);
-    }
-
     UE_LOG(LogRealGazeboUI, Log, TEXT("MainWidget: ViewerDirector reference set for camera integration"));
-}
-
-void URealGazeboMainWidget::HandleVehicleChangedByInput(AVehicleBasePawn* Vehicle)
-{
-    URealGazeboVehicleListItem* VehicleItem = Vehicle
-        ? GetVehicleItem(Vehicle->VehicleID)
-        : nullptr;
-
-    if (!VehicleItem && Vehicle)
-    {
-        UE_LOG(LogRealGazeboUI, Warning,
-               TEXT("MainWidget: No list item found for keyboard-selected vehicle ID %d_%d"),
-               Vehicle->VehicleID.VehicleType,
-               Vehicle->VehicleID.VehicleNum);
-    }
-
-    OnVehicleChangedByInput.Broadcast(VehicleItem);
 }
 
 AVehicleBasePawn* URealGazeboMainWidget::FindVehiclePawnByID(const FVehicleID& VehicleID) const

--- a/Source/RealGazeboUI/Private/Widgets/RealGazeboMainWidget.cpp
+++ b/Source/RealGazeboUI/Private/Widgets/RealGazeboMainWidget.cpp
@@ -126,6 +126,11 @@ void URealGazeboMainWidget::NativeConstruct()
 void URealGazeboMainWidget::NativeDestruct()
 {
     // Destructing UI
+
+    if (ViewerDirector.IsValid())
+    {
+        ViewerDirector->OnVehicleChangedByInput().RemoveAll(this);
+    }
     
     // Clear timer
     if (UWorld* World = GetWorld())
@@ -607,8 +612,38 @@ void URealGazeboMainWidget::SetVehicleTypeImageDataTable(UDataTable* DataTable)
 
 void URealGazeboMainWidget::SetViewerDirector(ARealGazeboViewerDirector* InViewerDirector)
 {
+    if (ViewerDirector.IsValid())
+    {
+        ViewerDirector->OnVehicleChangedByInput().RemoveAll(this);
+    }
+
     ViewerDirector = InViewerDirector;
+
+    if (ViewerDirector.IsValid())
+    {
+        ViewerDirector->OnVehicleChangedByInput().AddUObject(
+            this,
+            &URealGazeboMainWidget::HandleVehicleChangedByInput);
+    }
+
     UE_LOG(LogRealGazeboUI, Log, TEXT("MainWidget: ViewerDirector reference set for camera integration"));
+}
+
+void URealGazeboMainWidget::HandleVehicleChangedByInput(AVehicleBasePawn* Vehicle)
+{
+    URealGazeboVehicleListItem* VehicleItem = Vehicle
+        ? GetVehicleItem(Vehicle->VehicleID)
+        : nullptr;
+
+    if (!VehicleItem && Vehicle)
+    {
+        UE_LOG(LogRealGazeboUI, Warning,
+               TEXT("MainWidget: No list item found for keyboard-selected vehicle ID %d_%d"),
+               Vehicle->VehicleID.VehicleType,
+               Vehicle->VehicleID.VehicleNum);
+    }
+
+    OnVehicleChangedByInput.Broadcast(VehicleItem);
 }
 
 AVehicleBasePawn* URealGazeboMainWidget::FindVehiclePawnByID(const FVehicleID& VehicleID) const

--- a/Source/RealGazeboUI/Public/ViewerController/RealGazeboViewerDirector.h
+++ b/Source/RealGazeboUI/Public/ViewerController/RealGazeboViewerDirector.h
@@ -17,6 +17,8 @@
 class AVehicleBasePawn;
 class URealGazeboCameraControllerComponent;
 
+DECLARE_MULTICAST_DELEGATE_OneParam(FRealGazeboViewerVehicleChangedByInput, AVehicleBasePawn*);
+
 /**
  * Central camera director for RealGazebo viewer system
  * Simplified approach using UE5's DefaultPawn for manual camera
@@ -58,6 +60,9 @@ public:
     /** Get the currently followed vehicle */
     UFUNCTION(BlueprintCallable, BlueprintPure, Category = "RealGazebo|Viewer")
     AVehicleBasePawn* GetCurrentVehicle() const { return CurrentVehicle; }
+
+    /** Native event fired when the current vehicle changes through keyboard input */
+    FRealGazeboViewerVehicleChangedByInput& OnVehicleChangedByInput() { return VehicleChangedByInputDelegate; }
 
     /** Set the vehicle to follow (for first/third person cameras) */
     UFUNCTION(BlueprintCallable, Category = "RealGazebo|Viewer")
@@ -125,6 +130,12 @@ private:
     /** Input handler for third person camera mode (B key) */
     void InputThirdPersonCamera();
 
+    /** Input handler for selecting the previous vehicle (< key) */
+    void InputPreviousVehicle();
+
+    /** Input handler for selecting the next vehicle (> key) */
+    void InputNextVehicle();
+
     /** Input handler for camera preset 1 (1 key - C-Track) */
     void InputPreset1();
 
@@ -185,6 +196,9 @@ private:
     UPROPERTY()
     APawn* OriginalPawn;
 
+    /** Notifies UI integrations after comma/period vehicle switching */
+    FRealGazeboViewerVehicleChangedByInput VehicleChangedByInputDelegate;
+
     //----------------------------------------------------------
     // Internal Methods
     //----------------------------------------------------------
@@ -197,6 +211,9 @@ private:
 
     /** Discover all vehicles in the level */
     void DiscoverVehicles();
+
+    /** Select a vehicle relative to the currently possessed vehicle */
+    void CycleCurrentVehicle(int32 Direction);
 
     /** Find camera controller component for a specific vehicle */
     URealGazeboCameraControllerComponent* FindCameraControllerForVehicle(AVehicleBasePawn* Vehicle) const;

--- a/Source/RealGazeboUI/Public/Widgets/RealGazeboMainWidget.h
+++ b/Source/RealGazeboUI/Public/Widgets/RealGazeboMainWidget.h
@@ -20,11 +20,6 @@
 class UGazeboBridgeSubsystem;
 class ARealGazeboViewerDirector;
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
-    FRealGazeboVehicleListItemChangedByInput,
-    URealGazeboVehicleListItem*,
-    VehicleItem);
-
 /**
  * Vehicle sorting mode for UI list
  */
@@ -180,10 +175,6 @@ public:
     // Events (Blueprint Implementable)
     //----------------------------------------------------------
 
-    /** Broadcast when comma/period input changes the viewer vehicle */
-    UPROPERTY(BlueprintAssignable, Category = "Events|Camera")
-    FRealGazeboVehicleListItemChangedByInput OnVehicleChangedByInput;
-
     /** Called when a vehicle is selected in the list */
     UFUNCTION(BlueprintImplementableEvent, Category = "Events")
     void OnVehicleSelected(URealGazeboVehicleListItem* SelectedVehicle);
@@ -281,9 +272,6 @@ protected:
 
     /** Handle entry widget generation/recycling for proper selection state */
     void OnEntryWidgetGenerated(UUserWidget& GeneratedWidget);
-
-    /** Convert a keyboard-selected vehicle Pawn to its existing ListView item */
-    void HandleVehicleChangedByInput(class AVehicleBasePawn* Vehicle);
 
     //----------------------------------------------------------
     // Reset Button & Fade Functionality

--- a/Source/RealGazeboUI/Public/Widgets/RealGazeboMainWidget.h
+++ b/Source/RealGazeboUI/Public/Widgets/RealGazeboMainWidget.h
@@ -20,6 +20,11 @@
 class UGazeboBridgeSubsystem;
 class ARealGazeboViewerDirector;
 
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
+    FRealGazeboVehicleListItemChangedByInput,
+    URealGazeboVehicleListItem*,
+    VehicleItem);
+
 /**
  * Vehicle sorting mode for UI list
  */
@@ -175,6 +180,10 @@ public:
     // Events (Blueprint Implementable)
     //----------------------------------------------------------
 
+    /** Broadcast when comma/period input changes the viewer vehicle */
+    UPROPERTY(BlueprintAssignable, Category = "Events|Camera")
+    FRealGazeboVehicleListItemChangedByInput OnVehicleChangedByInput;
+
     /** Called when a vehicle is selected in the list */
     UFUNCTION(BlueprintImplementableEvent, Category = "Events")
     void OnVehicleSelected(URealGazeboVehicleListItem* SelectedVehicle);
@@ -272,6 +281,9 @@ protected:
 
     /** Handle entry widget generation/recycling for proper selection state */
     void OnEntryWidgetGenerated(UUserWidget& GeneratedWidget);
+
+    /** Convert a keyboard-selected vehicle Pawn to its existing ListView item */
+    void HandleVehicleChangedByInput(class AVehicleBasePawn* Vehicle);
 
     //----------------------------------------------------------
     // Reset Button & Fade Functionality


### PR DESCRIPTION
## Summary

This PR adds support for integrating Unreal-spawned vehicle Pawns with the Gazebo bridge and improves vehicle switching for Blueprint-based workflows.

## Changes

### UE-spawned vehicle registration

- Added `RegisterVehiclePawn` to register an existing `AVehicleBasePawn` with the bridge.
- Added `UnregisterVehiclePawn` with optional visual Pawn destruction.
- Reused registered Pawns when Gazebo pose data arrives instead of spawning duplicate visual Pawns.
- Updated vehicle pool tracking to recognize externally registered Pawns.
- Added cleanup handling for registered Pawns that are not owned by the vehicle pool.

### Keyboard vehicle switching

- Added previous/next vehicle switching using the comma and period keys.
- Limited switching to cases where the PlayerController currently possesses an `AVehicleBasePawn`.
- Added wrap-around navigation through the available vehicle list.
- Restored possession and the active camera mode when selecting the current vehicle after possessing an external Pawn.

### Blueprint vehicle-change event

- Exposed `OnVehicleChangedByInput` through `ARealGazeboManager`.
- Removed the event dependency on `URealGazeboMainWidget`.
- Added a `URealGazeboVehicleListItem` payload populated from the selected vehicle Pawn.
- Added safe ViewerDirector event binding and cleanup in the manager.

### Blueprint Vehicle ID comparison

- Added Blueprint `==` and `!=` operators for `FVehicleID`.
- Added `WithIdenticalViaEquality` so reflected struct comparisons use the native equality operator.
- Kept the comparison utilities in the `RealGazeboBridge` module without introducing a UI dependency.

## Motivation

Some integrations spawn vehicle Pawns in Unreal before receiving the corresponding Gazebo data. Previously, this could cause the bridge to spawn another visual Pawn for the same vehicle.

Vehicle switching also depended on `URealGazeboMainWidget`, making it difficult to use in projects with custom UI implementations. This PR moves the Blueprint event to `ARealGazeboManager` so it can be used independently of the bundled widget.

## Suggested Runtime Checks

- Register an Unreal-spawned Pawn and confirm that incoming Gazebo data does not create a duplicate Pawn.
- Switch vehicles using comma and period while possessing a vehicle Pawn.
- Confirm that switching is ignored while possessing a non-vehicle Pawn.
- Bind to `ARealGazeboManager::OnVehicleChangedByInput` and verify the `URealGazeboVehicleListItem` payload.
- Compare two `FVehicleID` values using the Blueprint `==` and `!=` nodes.